### PR TITLE
Install dev dependencies in CI to fix some tests

### DIFF
--- a/docker_build/bake_ci.hcl
+++ b/docker_build/bake_ci.hcl
@@ -36,7 +36,7 @@ target "ci_with_src" {
     "COPY --from=bake_ctx_dl_src_terrarium / /src/",
     "COPY --from=bake_ctx_dl_src_ci / /src/",
     "RUN . /venv/bin/activate && pip install -e /src/terrarium/bi_ci",
-    "RUN . /venv/bin/activate && cd /src/metapkg/ && poetry install --no-root --without=dev --with=ci",
+    "RUN . /venv/bin/activate && cd /src/metapkg/ && poetry install --no-root --with=dev --with=ci",
     # todo: include stubs into the metapkg pyproject.toml
     "RUN . /venv/bin/activate && pip install -r /src/ci/requirements_types.txt"
   ])

--- a/lib/dl_core/dl_core_tests/conftest.py
+++ b/lib/dl_core/dl_core_tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("aiohttp.pytest_plugin",)  # and it, in turn, includes 'pytest_asyncio.plugin'

--- a/lib/dl_core/dl_core_tests/db/conftest.py
+++ b/lib/dl_core/dl_core_tests/db/conftest.py
@@ -2,8 +2,5 @@ from dl_core_testing.initialization import initialize_core_test
 from dl_core_tests.db.config import CORE_TEST_CONFIG
 
 
-pytest_plugins = ("aiohttp.pytest_plugin",)  # and it, in turn, includes 'pytest_asyncio.plugin'
-
-
 def pytest_configure(config):  # noqa
     initialize_core_test(pytest_config=config, core_test_config=CORE_TEST_CONFIG)

--- a/lib/dl_core/dl_core_tests/unit/conftest.py
+++ b/lib/dl_core/dl_core_tests/unit/conftest.py
@@ -3,9 +3,6 @@ import asyncio
 import pytest
 
 
-pytest_plugins = ("aiohttp.pytest_plugin",)  # and it, in turn, includes 'pytest_asyncio.plugin'
-
-
 @pytest.fixture
 def loop(event_loop):
     asyncio.set_event_loop(event_loop)


### PR DESCRIPTION
For example, `pytest-asyncio` is in dev dependencies at the moment, and it is needed for tests => it is needed in CI