### PR TITLE
BI-5174: Add skip-tests and ci-allowed labels support for main workflow

### DIFF
--- a/.github/.scripts/gh_pull_request_check_label.sh
+++ b/.github/.scripts/gh_pull_request_check_label.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# expected env variables:
+GH_TOKEN=${GH_TOKEN}  # used by gh cli
+OWNER=${OWNER:-"{owner}"}
+REPO=${REPO:-"{repo}"}
+PULL_REQUEST_NUMBER=${PULL_REQUEST_NUMBER}
+LABEL=${LABEL}
+
+if [[ -z $PULL_REQUEST_NUMBER ]]; then
+    echo "DEBUG: PULL_REQUEST_NUMBER is not set, exiting with false result..." >&2
+    echo "false"
+    exit 0;
+fi
+
+
+# check if LABEL is in labels
+labels=$(gh api "/repos/${OWNER}/${REPO}/pulls/${PULL_REQUEST_NUMBER}" --jq ".labels[].name")
+
+if [[ -z $labels ]]; then
+    echo "ERROR: No labels found for PR($PULL_REQUEST_NUMBER), exiting..." >&2
+    echo "false"
+    exit 0;
+fi
+
+echo "DEBUG: Found labels for PR($PULL_REQUEST_NUMBER): $labels" >&2
+
+# if label not in labels, without partial match
+if [[ ! $labels =~ (^|[[:space:]])"$LABEL"($|[[:space:]]) ]]; then
+    echo "ERROR: Label $LABEL not found for PR($PULL_REQUEST_NUMBER), exiting..." >&2
+    echo "false"
+    exit 0;
+fi
+
+echo "INFO: Label $LABEL found for PR($PULL_REQUEST_NUMBER)" >&2
+echo "true"

--- a/.github/.scripts/gh_user_check_permission.sh
+++ b/.github/.scripts/gh_user_check_permission.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# expected env variables:
+GH_TOKEN=${GH_TOKEN}  # used by gh cli
+OWNER=${OWNER:-"{owner}"}
+REPO=${REPO:-"{repo}"}
+USER=${USER}
+PERMISSION=${PERMISSION:-"admin"}  # Possible values: admin, write, read, none
+
+declare -A permission_index
+permission_index=(["none"]=0 ["read"]=1 ["write"]=2 ["admin"]=3)
+
+# check if PERMISSION is in permission_index
+if [[ ! ${permission_index[$PERMISSION]+_} ]]; then
+    echo "ERROR: PERMISSION must be one of ${!permission_index[*]}, found $PERMISSION, exiting..." >&2
+    echo "false"
+    exit 0;
+fi
+
+
+user_permission=$(gh api "/repos/${OWNER}/${REPO}/collaborators/${USER}/permission" --jq ".role_name")
+
+if [[ -z $user_permission ]]; then
+    echo "ERROR: User $USER not found in $OWNER/$REPO, exiting..." >&2
+    echo "false"
+    exit 0;
+fi
+
+
+if [[ ${permission_index[$PERMISSION]} -gt ${permission_index[$user_permission]} ]]; then
+    echo "ERROR: User $USER has $user_permission permission, but $PERMISSION permission is required, exiting..." >&2
+    echo "false"
+    exit 0;
+fi
+
+echo "INFO: User $USER has $user_permission permission in $OWNER/$REPO, required permission is $PERMISSION" >&2
+echo "true"

--- a/.github/.scripts/git_config_save_directory.sh
+++ b/.github/.scripts/git_config_save_directory.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to solve "detected dubious ownership" error
+# https://github.com/actions/runner-images/issues/6775
+
+# expected env variables:
+REPOSITORY_NAME=${REPOSITORY_NAME}
+
+git config --global --add safe.directory .
+git config --global --add safe.directory "/__w/${REPOSITORY_NAME}/${REPOSITORY_NAME}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,9 +61,6 @@ jobs:
       contents: read
       pull-requests: read
 
-    outputs:
-      result: ${{ steps.result.outputs.result }}
-
     env:
       GH_TOKEN: ${{ github.token }}
       OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request:  # TODO: remove after merge BI-5174
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       test_targets:
@@ -21,41 +28,123 @@ on:
         description: "Timeout for pytest JOB in minutes"
 
 jobs:
+  drop-ci-approved-label:
+    name: Drop CI Allowed label if PR branch changed
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Drop label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          [[ ${{ github.event_name }} != "pull_request_target" ]] && exit 0
+          
+          action=${{ github.event.action }}
+          [[ $action == "labeled" || $action == "unlabeled" || $action == "opened" ]] && exit 0
+          
+          gh pr edit \
+            --repo ${{ github.event.repository.full_name }} \
+            --remove-label "ci-approved" \
+            ${{ github.event.pull_request.number }}
+
+  check-ci-allowed:
+    name: Check if CI allowed for PR
+    runs-on: ubuntu-22.04
+
+    needs: [ drop-ci-approved-label ]
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      result: ${{ steps.result.outputs.result }}
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check user permissions
+        id: check_user_permissions
+        working-directory: .github/.scripts
+        env:
+          USER: ${{ github.actor }}
+          PERMISSION: "write"
+        run: echo "result=$(./gh_user_check_permission.sh)" >> $GITHUB_OUTPUT
+
+      - name: Check PR permissions
+        id: check_pr_permissions
+        working-directory: .github/.scripts
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: "ci-approved"
+        run: echo "result=$(./gh_pull_request_check_label.sh)" >> $GITHUB_OUTPUT
+
+      - name: Combine results
+        id: result
+        run: |
+          user_allowed=${{ steps.check_user_permissions.outputs.result }}
+          pr_allowed=${{ steps.check_pr_permissions.outputs.result }}
+          
+          [[ $user_allowed != "true" && $pr_allowed != "true" ]] && exit 1
+          
+          echo "PR is allowed to run CI"
+
   gh_build_image:
-    runs-on: [ self-hosted, linux ]
+    runs-on: [ self-hosted, linux, light ]
+
+    needs: [ check-ci-allowed ]
+
     permissions:
       packages: write
       contents: read
+
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/debian_docker:latest"
       options: -v /var/run/docker.sock:/var/run/docker.sock
       credentials:
-        username: ${{ github.triggering_actor }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GIT_SHA: "${{ github.sha }}"
+
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
           registry: "ghcr.io"
-          username: ${{ github.triggering_actor }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Cleanup build folder'
+
+      - name: Cleanup build folder
         run: |
           rm -rf ./* || true
           rm -rf ./.??* || true
       - name: Checkout code
         uses: actions/checkout@v4
-      - run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      - name: Fix dubious ownership
+        run: .github/.scripts/git_config_save_directory.sh
+        env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+
       - run: |
           export ROOT_DIR="$(realpath .)"
           /bin/bash ci/build_naive.sh
 
   router:
-    runs-on: [self-hosted, linux, light]
+    runs-on: [ self-hosted, linux, light ]
     needs: gh_build_image
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/datalens_ci_with_code:${{ github.sha }}"
@@ -65,7 +154,7 @@ jobs:
     outputs:
       affected: ${{ steps.get_affected.outputs.affected }}
     steps:
-    - name: 'Cleanup build folder'
+    - name: Cleanup build folder
       run: |
         rm -rf ./* || true
         rm -rf ./.??* || true
@@ -73,8 +162,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - run: git config --global --add safe.directory .
-    - run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+    - name: Fix dubious ownership
+      run: .github/.scripts/git_config_save_directory.sh
+      env:
+        REPOSITORY_NAME: ${{ github.event.repository.name }}
     - run: git fetch origin main
     - name: Extract base commit
       run: |
@@ -106,9 +197,41 @@ jobs:
       env:
         TEST_TARGET_OVERRIDE: ${{ github.event.inputs.test_targets }}
 
+  check-skip-tests-label:
+    name: Check PR skip tests label
+    runs-on: ubuntu-22.04
+
+    needs: [ check-ci-allowed ]
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      result: ${{ steps.check_skip_label.outputs.result }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check PR skip label
+        id: check_skip_label
+        working-directory: .github/.scripts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          LABEL: "tests-force-skipped"
+        run: echo "result=$(./gh_pull_request_check_label.sh)" >> $GITHUB_OUTPUT
+
   pytest_split:
-    runs-on: [ self-hosted, linux ]
-    needs: router
+    name: Split pytest into jobs for each test type
+    runs-on: [ self-hosted, linux, light ]
+
+    needs: [ router, check-skip-tests-label ]
+    if: ${{ needs.check-skip-tests-label.outputs.result != 'true' }}
+
     # if: ${{ github.event.inputs.run_mypy_only != 'true' }}
     container:
       image: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/datalens_ci_with_code:${{ github.sha }}"
@@ -120,7 +243,7 @@ jobs:
       split_fat: ${{ steps.get_split.outputs.split_fat }}
       split_ext_public: ${{ steps.get_split.outputs.split_ext_public }}
     steps:
-      - name: 'Cleanup build folder'
+      - name: Cleanup build folder
         run: |
           rm -rf ./* || true
           rm -rf ./.??* || true
@@ -128,7 +251,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
+      - name: Fix dubious ownership
+        run: .github/.scripts/git_config_save_directory.sh
+        env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
       - name: Run python script to split job for general and fat runners
         id: get_split
         run: |
@@ -305,7 +431,7 @@ jobs:
     name: "🐲 mypy"
     timeout-minutes: ${{ inputs.pytest_timeout_minutes && fromJSON(inputs.pytest_timeout_minutes ) || 10 }}
     steps:
-      - name: "Cleanup folder"
+      - name: Cleanup build folder
         run: |
           rm -rf ./* || true
           rm -rf ./.??* || true
@@ -321,8 +447,30 @@ jobs:
         env:
           PYTHONUNBUFFERED: "1"
 
+  test-results:
+    name: Test results
+    runs-on: ubuntu-22.04
+
+    needs: [ check-skip-tests-label, run_tests_base, run_tests_fat, run_tests_ext_public ]
+    if: ${{ always() }}
+
+    steps:
+      - name: Test results
+        run: |
+          skip_tests=${{ needs.check-skip-tests-label.outputs.result }}
+          [[ $skip_tests == "true" ]] && exit 0
+
+          result_base=${{ needs.run_tests_base.result }}
+          [[ $result_base != "success" && $result_base != "skipped" ]] && exit 1
+          result_fat=${{ needs.run_tests_fat.result }}
+          [[ $result_fat != "success" && $result_fat != "skipped" ]] && exit 1
+          result_ext_public=${{ needs.run_tests_ext_public.result }}
+          [[ $result_ext_public != "success" && $result_ext_public != "skipped" ]] && exit 1
+          
+          echo "All tests passed"
+
   publish-result:
-    runs-on: [self-hosted, linux ]
+    runs-on: [ self-hosted, linux, light ]
     needs: [ "run_tests_base", "run_tests_fat", "run_tests_ext_public" ]
     if: ${{ !cancelled() && github.event.inputs.run_mypy_only != 'true' }}
     permissions:
@@ -345,7 +493,7 @@ jobs:
           report_individual_runs: "true"
 
   codestyle_all_without_ruff:
-    runs-on: [self-hosted, linux, light]
+    runs-on: [ self-hosted, linux, light ]
     needs: gh_build_image
     container:
       # until https://github.com/github/docs/issues/25520 is resolved, using vars
@@ -354,7 +502,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: 'Cleanup build folder'
+      - name: Cleanup build folder
         run: |
           rm -rf ./* || true
           rm -rf ./.??* || true


### PR DESCRIPTION
Preventing main CI to start for users with read rights or less.

Adding label support for workflow:
ci-approved: if PR is labeled, workflow will work no matter the user created PR
If commit is pushed to the branch, label will be dropped

tests-force-skipped: if PR is labeled, workflow will skip tests and mark test-results job as green ignoring results
test-results job will soon become required for merge

Changing trigger to pull_request_target to allow fork PRs to use write permissions