### PR TITLE
Refactored error handling in adapters

### DIFF
--- a/lib/dl_connector_bigquery/dl_connector_bigquery/core/adapters.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery/core/adapters.py
@@ -23,6 +23,7 @@ from dl_core.connection_models.common_models import (
     SchemaIdent,
     TableIdent,
 )
+from dl_core.connectors.base.error_handling import ExceptionMaker
 
 from dl_connector_bigquery.core.constants import CONNECTION_TYPE_BIGQUERY
 from dl_connector_bigquery.core.error_transformer import big_query_db_error_transformer
@@ -46,7 +47,6 @@ class BigQueryDefaultAdapter(BaseClassicAdapter[BigQueryConnTargetDTO]):
     conn_type = CONNECTION_TYPE_BIGQUERY
     dsn_template = "{dialect}://{project_id}"
     conn_line_constructor_type = BigQueryConnLineConstructor
-    _error_transformer = big_query_db_error_transformer
 
     _type_code_to_sa = {
         "STRING": bq_types.STRING,
@@ -62,6 +62,9 @@ class BigQueryDefaultAdapter(BaseClassicAdapter[BigQueryConnTargetDTO]):
         "BIGNUMERIC": bq_types.BIGNUMERIC,
         # TODO: ARRAY
     }
+
+    def _make_exception_maker(self) -> ExceptionMaker:
+        return ExceptionMaker(error_transformer=big_query_db_error_transformer)
 
     def get_default_db_name(self) -> Optional[str]:
         return self._target_dto.project_id

--- a/lib/dl_connector_mysql/dl_connector_mysql/core/adapters_mysql.py
+++ b/lib/dl_connector_mysql/dl_connector_mysql/core/adapters_mysql.py
@@ -5,7 +5,7 @@ from typing import ClassVar
 import attr
 
 from dl_core.connection_executors.adapters.adapters_base_sa_classic import BaseClassicAdapter
-from dl_core.connectors.base.error_transformer import DbErrorTransformer
+from dl_core.connectors.base.error_handling import ExceptionMaker
 
 from dl_connector_mysql.core.adapters_base_mysql import BaseMySQLAdapter
 from dl_connector_mysql.core.error_transformer import sync_mysql_db_error_transformer
@@ -17,7 +17,9 @@ class MySQLAdapter(BaseMySQLAdapter, BaseClassicAdapter[MySQLConnTargetDTO]):
     execution_options = {
         "stream_results": True,
     }
-    _error_transformer: ClassVar[DbErrorTransformer] = sync_mysql_db_error_transformer
+
+    def _make_exception_maker(self) -> ExceptionMaker:
+        return ExceptionMaker(error_transformer=sync_mysql_db_error_transformer)
 
     def get_connect_args(self) -> dict:
         return dict(charset="utf8", local_infile=0, ssl={"ssl_check_hostname": False})

--- a/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql_base/adapters_postgres.py
+++ b/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql_base/adapters_postgres.py
@@ -18,6 +18,7 @@ import sqlalchemy as sa
 
 from dl_core.connection_executors.adapters.adapters_base_sa_classic import BaseClassicAdapter
 from dl_core.connection_models.common_models import TableIdent
+from dl_core.connectors.base.error_handling import ExceptionMaker
 
 from dl_connector_postgresql.core.postgresql_base.adapters_base_postgres import (
     OID_KNOWLEDGE,
@@ -36,14 +37,15 @@ if TYPE_CHECKING:
 
 @attr.s()
 class PostgresAdapter(BasePostgresAdapter, BaseClassicAdapter[PostgresConnTargetDTO]):
-    _error_transformer = sync_pg_db_error_transformer
-
     execution_options = {
         "stream_results": True,
     }
 
     _LIST_ALL_TABLES_QUERY = PG_LIST_SOURCES_ALL_SCHEMAS_SQL
     _LIST_TABLE_NAMES_QUERY = PG_LIST_TABLE_NAMES
+
+    def _make_exception_maker(self) -> ExceptionMaker:
+        return ExceptionMaker(error_transformer=sync_pg_db_error_transformer)
 
     def get_connect_args(self) -> dict:
         return dict(

--- a/lib/dl_connector_postgresql/dl_connector_postgresql_tests/unit/test_error_transformer.py
+++ b/lib/dl_connector_postgresql/dl_connector_postgresql_tests/unit/test_error_transformer.py
@@ -21,16 +21,16 @@ NAME_OR_SERVICE_NOT_KNOWN_MSG = """
 def test_name_or_service_not_known_sync():
     transformer = sync_pg_db_error_transformer
 
-    parameters = transformer.make_bi_error_parameters(
+    exc_info = transformer.make_bi_error_parameters(
         wrapper_exc=psycopg2.OperationalError(NAME_OR_SERVICE_NOT_KNOWN_MSG)
     )
 
-    assert parameters[0] == SourceHostNotKnownError
+    assert exc_info.exc_cls == SourceHostNotKnownError
 
 
 def test_name_or_service_not_known_async():
     transformer = make_async_pg_error_transformer()
 
-    parameters = transformer.make_bi_error_parameters(wrapper_exc=gaierror(NAME_OR_SERVICE_NOT_KNOWN_MSG))
+    exc_info = transformer.make_bi_error_parameters(wrapper_exc=gaierror(NAME_OR_SERVICE_NOT_KNOWN_MSG))
 
-    assert parameters[0] == SourceHostNotKnownError
+    assert exc_info.exc_cls == SourceHostNotKnownError

--- a/lib/dl_connector_snowflake/dl_connector_snowflake/core/adapters.py
+++ b/lib/dl_connector_snowflake/dl_connector_snowflake/core/adapters.py
@@ -23,6 +23,7 @@ from dl_core.connection_models.common_models import (
     DBIdent,
     SATextTableDefinition,
 )
+from dl_core.connectors.base.error_handling import ExceptionMaker
 from dl_core.db.native_type import SATypeSpec
 
 from dl_connector_snowflake.core.constants import CONNECTION_TYPE_SNOWFLAKE
@@ -61,7 +62,6 @@ def construct_creator_func(target_dto: SnowFlakeConnTargetDTO) -> Callable:
 @attr.s(kw_only=True)
 class SnowFlakeDefaultAdapter(BaseClassicAdapter, BaseSAAdapter[SnowFlakeConnTargetDTO]):
     conn_type = CONNECTION_TYPE_SNOWFLAKE
-    _error_transformer = snowflake_error_transformer
 
     # https://docs.snowflake.com/en/user-guide/python-connector-api#type-codes
     _type_code_to_sa = {
@@ -80,6 +80,9 @@ class SnowFlakeDefaultAdapter(BaseClassicAdapter, BaseSAAdapter[SnowFlakeConnTar
         12: ssa.TIME,
         13: ssa.BOOLEAN,
     }
+
+    def _make_exception_maker(self) -> ExceptionMaker:
+        return ExceptionMaker(error_transformer=snowflake_error_transformer)
 
     def _cursor_column_to_sa(self, cursor_col, require: bool = True) -> Optional[SATypeSpec]:  # type: ignore  # TODO: fix
         """

--- a/lib/dl_connector_ydb/dl_connector_ydb/core/base/adapter.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/base/adapter.py
@@ -109,18 +109,3 @@ class YQLAdapterBase(BaseClassicAdapter[_DBA_YQL_BASE_DTO_TV]):
             else None
             for type_name_norm in type_names_norm
         )
-
-    @classmethod
-    def make_exc(  # TODO:  Move to ErrorTransformer
-        cls, wrapper_exc: Exception, orig_exc: Optional[Exception], debug_compiled_query: Optional[str]
-    ) -> Tuple[Type[exc.DatabaseQueryError], DBExcKWArgs]:
-        exc_cls, kw = super().make_exc(wrapper_exc, orig_exc, debug_compiled_query)
-
-        try:
-            message = wrapper_exc.message  # type: ignore  # 2024-01-24 # TODO: "Exception" has no attribute "message"  [attr-defined]
-        except Exception:
-            pass
-        else:
-            kw["db_message"] = kw.get("db_message") or message
-
-        return exc_cls, kw

--- a/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_aiohttp.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_aiohttp.py
@@ -111,6 +111,7 @@ class AiohttpDBAdapter(AsyncDirectDBAdapter, metaclass=abc.ABCMeta):
 
     @contextlib.contextmanager
     def wrap_execute_excs(self, query: DBAdapterQuery, stage: Optional[str]) -> Generator[None, None, None]:
+        # TODO: Move to ErrorTransformer/ExceptionMaker
         try:
             try:
                 yield None

--- a/lib/dl_core/dl_core/connection_executors/adapters/mixins.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/mixins.py
@@ -11,7 +11,6 @@ from typing import (
     Tuple,
 )
 
-import attr
 from sqlalchemy.sql.type_api import TypeEngine
 
 from dl_constants.enums import ConnectionType


### PR DESCRIPTION
Moved error handling logic out of adapters to `ExceptionMaker` and its custom subclasses.
This is needed to enable the same error handling logic outside of adapters. And also to get rid of yet another adapter mixin. Also this standardizes error handling interfaces