### PR TITLE
Fixed initialization of adapter actions (via attrs post-init)

### DIFF
--- a/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse_base/adapters.py
+++ b/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse_base/adapters.py
@@ -129,9 +129,6 @@ class BaseClickHouseAdapter(BaseClassicAdapter["BaseClickHouseConnTargetDTO"], B
 
     _dt_with_system_tz = True
 
-    def __attrs_post_init__(self) -> None:
-        super().__attrs_post_init__()
-
     def _get_dsn_params_from_headers(self) -> dict[str, str]:
         return self._convert_headers_to_dsn_params(self.ch_utils.get_context_headers(self._req_ctx_info))
 

--- a/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse_base/adapters.py
+++ b/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse_base/adapters.py
@@ -121,12 +121,16 @@ class BaseClickHouseConnLineConstructor(ClassicSQLConnLineConstructor[_TARGET_DT
         }
 
 
+@attr.s
 class BaseClickHouseAdapter(BaseClassicAdapter["BaseClickHouseConnTargetDTO"], BaseSSLCertAdapter):
     allow_sa_text_as_columns_source = True
     ch_utils: ClassVar[Type[ClickHouseBaseUtils]] = ClickHouseBaseUtils
     conn_line_constructor_type: ClassVar[Type[BaseClickHouseConnLineConstructor]] = BaseClickHouseConnLineConstructor
 
     _dt_with_system_tz = True
+
+    def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()
 
     def _get_dsn_params_from_headers(self) -> dict[str, str]:
         return self._convert_headers_to_dsn_params(self.ch_utils.get_context_headers(self._req_ctx_info))

--- a/lib/dl_core/dl_core/connection_executors/adapters/adapters_base.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/adapters_base.py
@@ -92,7 +92,7 @@ class SyncDirectDBAdapter(CommonBaseDirectAdapter[_TARGET_DTO_TV], metaclass=abc
     def __attrs_post_init__(self) -> None:
         self._initialize_actions()
 
-    def _initialize_actions(self):
+    def _initialize_actions(self) -> None:
         self._sync_db_version_action = self._make_sync_db_version_action()
         self._sync_schema_names_action = self._make_sync_schema_names_action()
         self._sync_table_names_action = self._make_sync_table_names_action()

--- a/lib/dl_core/dl_core/connection_executors/adapters/adapters_base.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/adapters_base.py
@@ -78,6 +78,7 @@ class DBAdapterQueryResult:
 _TARGET_DTO_TV = TypeVar("_TARGET_DTO_TV", bound="ConnTargetDTO")
 
 
+@attr.s
 class SyncDirectDBAdapter(CommonBaseDirectAdapter[_TARGET_DTO_TV], metaclass=abc.ABCMeta):
     # Adapter action fields
     _sync_db_version_action: SyncDBVersionAdapterAction = attr.ib(init=False)
@@ -88,42 +89,17 @@ class SyncDirectDBAdapter(CommonBaseDirectAdapter[_TARGET_DTO_TV], metaclass=abc
     _sync_table_exists_action: SyncTableExistsAdapterAction = attr.ib(init=False)
     _sync_typed_query_action: SyncTypedQueryAdapterAction = attr.ib(init=False)
 
-    # Action defaults
+    def __attrs_post_init__(self) -> None:
+        self._initialize_actions()
 
-    @_sync_db_version_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_db_version_action(self) -> SyncDBVersionAdapterAction:
-        return self._make_sync_db_version_action()
-
-    @_sync_schema_names_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_schema_names_action(self) -> SyncSchemaNamesAdapterAction:
-        return self._make_sync_schema_names_action()
-
-    @_sync_table_names_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_table_names_action(self) -> SyncTableNamesAdapterAction:
-        return self._make_sync_table_names_action()
-
-    @_sync_test_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_test_action(self) -> SyncTestAdapterAction:
-        return self._make_sync_test_action()
-
-    @_sync_table_info_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_test_action(self) -> SyncTableInfoAdapterAction:
-        return self._make_sync_table_info_action()
-
-    @_sync_table_exists_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_table_exists_action(self) -> SyncTableExistsAdapterAction:
-        return self._make_sync_table_exists_action()
-
-    @_sync_typed_query_action.default  # type: ignore  # attrs field default
-    @final
-    def __make_default_sync_typed_query_action(self) -> SyncTypedQueryAdapterAction:
-        return self._make_sync_typed_query_action()
+    def _initialize_actions(self):
+        self._sync_db_version_action = self._make_sync_db_version_action()
+        self._sync_schema_names_action = self._make_sync_schema_names_action()
+        self._sync_table_names_action = self._make_sync_table_names_action()
+        self._sync_test_action = self._make_sync_test_action()
+        self._sync_table_info_action = self._make_sync_table_info_action()
+        self._sync_table_exists_action = self._make_sync_table_exists_action()
+        self._sync_typed_query_action = self._make_sync_typed_query_action()
 
     # Action factory methods
 

--- a/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_aiohttp.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_aiohttp.py
@@ -61,6 +61,7 @@ class AiohttpDBAdapter(AsyncDirectDBAdapter, metaclass=abc.ABCMeta):
                 )
             ),
         )
+        super().__attrs_post_init__()
 
     def create_aiohttp_connector(self, ssl_context: Optional[ssl.SSLContext]) -> aiohttp.TCPConnector:
         return aiohttp.TCPConnector(

--- a/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_base.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_base.py
@@ -111,42 +111,17 @@ class AsyncDBAdapter(metaclass=abc.ABCMeta):
     _async_table_exists_action: AsyncTableExistsAdapterAction = attr.ib(init=False)
     _async_typed_query_action: AsyncTypedQueryAdapterAction = attr.ib(init=False)
 
-    # Action defaults
+    def __attrs_post_init__(self) -> None:
+        self._initialize_actions()
 
-    @_async_db_version_action.default
-    @final
-    def __make_default_async_db_version_action(self) -> AsyncDBVersionAdapterAction:
-        return self._make_async_db_version_action()
-
-    @_async_schema_names_action.default
-    @final
-    def __make_default_async_schema_names_action(self) -> AsyncSchemaNamesAdapterAction:
-        return self._make_async_schema_names_action()
-
-    @_async_table_names_action.default
-    @final
-    def __make_default_async_table_names_action(self) -> AsyncTableNamesAdapterAction:
-        return self._make_async_table_names_action()
-
-    @_async_test_action.default
-    @final
-    def __make_default_async_test_action(self) -> AsyncTestAdapterAction:
-        return self._make_async_test_action()
-
-    @_async_table_info_action.default  # type: ignore  # 2024-01-24 # TODO: Name "__make_async_test_action" already defined on line 124  [no-redef]
-    @final
-    def __make_default_async_test_action(self) -> AsyncTableInfoAdapterAction:
-        return self._make_async_table_info_action()
-
-    @_async_table_exists_action.default
-    @final
-    def __make_default_async_table_exists_action(self) -> AsyncTableExistsAdapterAction:
-        return self._make_async_table_exists_action()
-
-    @_async_typed_query_action.default
-    @final
-    def __make_default_async_typed_query_action(self) -> AsyncTypedQueryAdapterAction:
-        return self._make_async_typed_query_action()
+    def _initialize_actions(self):
+        self._async_db_version_action = self._make_async_db_version_action()
+        self._async_schema_names_action = self._make_async_schema_names_action()
+        self._async_table_names_action = self._make_async_table_names_action()
+        self._async_test_action = self._make_async_test_action()
+        self._async_table_info_action = self._make_async_table_info_action()
+        self._async_table_exists_action = self._make_async_table_exists_action()
+        self._async_typed_query_action = self._make_async_typed_query_action()
 
     # Action factory methods
 

--- a/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_base.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_base.py
@@ -114,7 +114,7 @@ class AsyncDBAdapter(metaclass=abc.ABCMeta):
     def __attrs_post_init__(self) -> None:
         self._initialize_actions()
 
-    def _initialize_actions(self):
+    def _initialize_actions(self) -> None:
         self._async_db_version_action = self._make_async_db_version_action()
         self._async_schema_names_action = self._make_async_schema_names_action()
         self._async_table_names_action = self._make_async_table_names_action()

--- a/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_remote.py
+++ b/lib/dl_core/dl_core/connection_executors/adapters/async_adapters_remote.py
@@ -100,6 +100,8 @@ class RemoteAsyncAdapter(AsyncDBAdapter):
     DEFAULT_REL_PATH = "/execute_action"
 
     def __attrs_post_init__(self) -> None:
+        super().__attrs_post_init__()
+
         if self._force_async_rqe:
             self._use_sync_rqe = False
         else:


### PR DESCRIPTION
Switched action initialization to using `__attrs_post_init__` because otherwise action factories do not have access to other attrs fields.