### PR TITLE
BI-5359: apply mutations to node's children before the node itself

### DIFF
--- a/lib/dl_connector_oracle/dl_connector_oracle_tests/db/api/test_complex_queries.py
+++ b/lib/dl_connector_oracle/dl_connector_oracle_tests/db/api/test_complex_queries.py
@@ -9,10 +9,4 @@ class TestOracleBasicComplexQueries(OracleDataApiTestBase, DefaultBasicComplexQu
         mark_features_skipped={
             DefaultBasicComplexQueryTestSuite.feature_window_functions: "Native window functions are not implemented"
         },
-        mark_tests_failed={
-            DefaultBasicComplexQueryTestSuite.test_month_ago_for_shorter_month: (
-                "FIXME: Oracle cannot add a month to 2021-01-31 (2021-02-31 doesn't exist;"
-                " db error: ORA-01839: date not valid for month specified)"
-            ),
-        },
     )

--- a/lib/dl_formula/dl_formula/core/nodes.py
+++ b/lib/dl_formula/dl_formula/core/nodes.py
@@ -322,16 +322,16 @@ class FormulaItem(abc.ABC):
         to_replace: dict[int, FormulaItem] = {}
 
         for idx, child in enumerate(self.__children):
+            modified_child = child.replace_nodes(match_func, replace_func, parent_stack_w_self)
+            if modified_child is not child or modified_child != child:
+                child = to_replace[idx] = modified_child
+                is_modified = True
+
             if match_func(child, parent_stack_w_self):
                 modified_child = replace_func(child, parent_stack_w_self)
                 if modified_child is not child or modified_child != child:
-                    child = to_replace[idx] = modified_child
+                    to_replace[idx] = modified_child
                     is_modified = True
-
-            modified_child = child.replace_nodes(match_func, replace_func, parent_stack_w_self)
-            if modified_child is not child or modified_child != child:
-                to_replace[idx] = modified_child
-                is_modified = True
 
         if is_modified:
             children = cast(

--- a/lib/dl_formula/dl_formula/mutation/general.py
+++ b/lib/dl_formula/dl_formula/mutation/general.py
@@ -306,7 +306,7 @@ class OptimizeConstFuncMutation(FormulaMutation):
                 if isinstance(when_arg, nodes.BaseLiteral):
                     when_expr_value = when_arg.value
                     if when_expr_value != case_expr_value:
-                        # The "when" is not the same aas "case", so skip this branch
+                        # The "when" is not the same as "case", so skip this branch
                         # (don't add it to the optimized CASE)
                         pass
                     else:  # They are equal

--- a/lib/dl_formula/dl_formula_tests/unit/mutation/test_general.py
+++ b/lib/dl_formula/dl_formula_tests/unit/mutation/test_general.py
@@ -181,6 +181,50 @@ def test_optimize_if_mutation():
     assert formula_obj == n.formula(n.field("then field 3"))
 
 
+def test_optimize_if_mutation_with_const_comparison():
+    # Check false comparison result in removal of a corresponding branch
+    formula_obj = n.formula(
+        n.func.IF(
+            n.binary("==", left=n.lit(2), right=n.lit(3)),
+            n.field("then field 1"),
+            n.binary("!=", left=n.lit(2), right=n.lit(2)),
+            n.field("then field 2"),
+            n.field("else field"),
+        )
+    )
+    formula_obj = apply_mutations(
+        formula_obj,
+        mutations=[
+            OptimizeConstComparisonMutation(),
+            OptimizeConstFuncMutation(),
+        ],
+    )
+    assert formula_obj == n.formula(n.field("else field"))
+
+    # Check true comparison result in single field result
+    formula_obj = n.formula(
+        n.func.IF(
+            n.field("cond 1"),
+            n.field("then field 1"),
+            n.binary("!=", left=n.lit(2), right=n.lit(2)),
+            n.field("then field 2"),
+            n.binary("==", left=n.lit(2), right=n.lit(2)),
+            n.field("then field 3"),
+            n.field("cond 4"),
+            n.field("then field 4"),
+            n.field("else field"),
+        )
+    )
+    formula_obj = apply_mutations(
+        formula_obj,
+        mutations=[
+            OptimizeConstComparisonMutation(),
+            OptimizeConstFuncMutation(),
+        ],
+    )
+    assert formula_obj == n.formula(n.field("then field 3"))
+
+
 def test_optimize_case_mutation():
     # Check removal of false conditions
     formula_obj = n.formula(


### PR DESCRIPTION
Currently, mutations apply to a node first and to its children second. This results in the following bug: expressions like `if 1=1 then expr1 else expr2` are simplified to `if 1 then expr1 else expr2` because `1=1` doesn't constitute as a constant literal when applying the if-case optimization, but they can be further simplified to just `expr1`.

We should apply mutations to children first, in this case we will first optimize `1=1` and only then the if expression.