### PR TITLE
BI-5359: remove an erroneous type check on making a join expression

### DIFF
--- a/lib/dl_query_processing/dl_query_processing/multi_query/splitters/mask_based.py
+++ b/lib/dl_query_processing/dl_query_processing/multi_query/splitters/mask_based.py
@@ -303,12 +303,8 @@ class MultiQuerySplitter(MultiQuerySplitterBase):
                 right_expr: formula_nodes.FormulaItem
                 left_expr: formula_nodes.FormulaItem
                 if isinstance(condition, formula_fork_nodes.SelfEqualityJoinCondition):
-                    expr = condition.expr
-                    if not isinstance(expr, (formula_nodes.Field, formula_aux_nodes.ErrorNode)):
-                        raise TypeError(f"Expected field or error node, got {type(expr)}")
-
-                    left_expr = expr
-                    right_expr = expr
+                    left_expr = condition.expr
+                    right_expr = condition.expr
                 elif isinstance(condition, formula_fork_nodes.BinaryJoinCondition):
                     left_expr = condition.expr
                     right_expr = condition.fork_expr


### PR DESCRIPTION
There seems to be no reason for such restriction, as one can safely use complex expressions in `JOIN ON` clause. Moreover, it is possible under a specific set of circumstances to achieve a situation where such clause is required (see a test for example). 