### PR TITLE
fix(connectors): BI-5777 handle google api errors & bad creds error in BQ connector

### DIFF
--- a/lib/dl_api_lib/dl_api_lib/error_handling.py
+++ b/lib/dl_api_lib/dl_api_lib/error_handling.py
@@ -54,6 +54,7 @@ EXCEPTION_CODES = {
     common_exc.QueryConstructorError: status.BAD_REQUEST,
     common_exc.ResultRowCountLimitExceeded: status.BAD_REQUEST,
     common_exc.TableNameNotConfiguredError: status.BAD_REQUEST,
+    common_exc.MalformedCredentialsError: status.BAD_REQUEST,
     common_exc.NotAvailableError: status.BAD_REQUEST,
     common_exc.InvalidFieldError: status.BAD_REQUEST,
     common_exc.FieldNotFound: status.BAD_REQUEST,

--- a/lib/dl_connector_bigquery/dl_connector_bigquery/core/sa_types.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery/core/sa_types.py
@@ -8,7 +8,7 @@ from dl_connector_bigquery.core.constants import BACKEND_TYPE_BIGQUERY
 
 SQLALCHEMY_BIGQUERY_TYPES = {
     (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.DATE)): simple_instantiator(bq_types.DATE),
-    (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.DATETIME)): simple_instantiator(bq_types.DATE),
+    (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.DATETIME)): simple_instantiator(bq_types.DATETIME),
     (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.STRING)): simple_instantiator(bq_types.STRING),
     (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.BOOLEAN)): simple_instantiator(bq_types.BOOLEAN),
     (BACKEND_TYPE_BIGQUERY, make_native_type(bq_types.INTEGER)): simple_instantiator(bq_types.INTEGER),

--- a/lib/dl_connector_bigquery/dl_connector_bigquery/core/type_transformer.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery/core/type_transformer.py
@@ -24,6 +24,7 @@ class BigQueryTypeTransformer(TypeTransformer):
         UserDataType.date: make_native_type(bq_types.DATE),
         UserDataType.genericdatetime: make_native_type(bq_types.DATETIME),
         UserDataType.string: make_native_type(bq_types.STRING),
+        UserDataType.uuid: make_native_type(bq_types.STRING),
         UserDataType.boolean: make_native_type(bq_types.BOOLEAN),
         UserDataType.integer: make_native_type(bq_types.INTEGER),
         UserDataType.float: make_native_type(bq_types.FLOAT),

--- a/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/base.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/base.py
@@ -29,6 +29,24 @@ class BigQueryConnectionTestBase(BaseBigQueryTestClass, ConnectionTestBase):
         )
 
 
+class BigQueryConnectionTestMalformedCreds(BigQueryConnectionTestBase):
+    @pytest.fixture(scope="class")
+    def connection_params(self, bq_secrets) -> dict:
+        return dict(
+            project_id=bq_secrets.get_project_id(),
+            credentials=bq_secrets.get_creds() + "asdf",
+        )
+
+
+class BigQueryConnectionTestBadProjectId(BigQueryConnectionTestBase):
+    @pytest.fixture(scope="class")
+    def connection_params(self, bq_secrets) -> dict:
+        return dict(
+            project_id=bq_secrets.get_project_id() + "123",
+            credentials=bq_secrets.get_creds(),
+        )
+
+
 class BigQueryDatasetTestBase(BigQueryConnectionTestBase, DatasetTestBase):
     @pytest.fixture(scope="class")
     def dataset_params(self, sample_table) -> dict:

--- a/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/test_connection.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/test_connection.py
@@ -1,7 +1,42 @@
-from dl_api_lib_testing.connector.connection_suite import DefaultConnectorConnectionTestSuite
+from typing import Optional
 
-from dl_connector_bigquery_tests.ext.api.base import BigQueryConnectionTestBase
+from dl_api_client.dsmaker.api.http_sync_base import SyncHttpClientBase
+from dl_api_lib_testing.connection_base import ConnectionTestBase
+from dl_api_lib_testing.connector.connection_suite import DefaultConnectorConnectionTestSuite
+from dl_testing.regulated_test import RegulatedTestCase
+
+from dl_connector_bigquery_tests.ext.api.base import (
+    BigQueryConnectionTestBadProjectId,
+    BigQueryConnectionTestBase,
+    BigQueryConnectionTestMalformedCreds,
+)
 
 
 class TestBigQueryConnection(BigQueryConnectionTestBase, DefaultConnectorConnectionTestSuite):
+    pass
+
+
+class ErrorHandlingTestBase(BigQueryConnectionTestBase, ConnectionTestBase, RegulatedTestCase):
+    def test_connection_sources_error(
+        self,
+        control_api_sync_client: SyncHttpClientBase,
+        saved_connection_id: str,
+        bi_headers: Optional[dict[str, str]],
+    ) -> None:
+        resp = control_api_sync_client.get(
+            url=f"/api/v1/connections/{saved_connection_id}/info/sources",
+            headers=bi_headers,
+        )
+        assert resp.status_code == 400, resp.json
+        resp_data = resp.json
+        assert "code" in resp_data, resp_data
+        assert "message" in resp_data, resp_data
+        print(resp.json)
+
+
+class TestErrorHandlingMalformedCreds(BigQueryConnectionTestMalformedCreds, ErrorHandlingTestBase):
+    pass
+
+
+class TestErrorHandlingBadProjectId(BigQueryConnectionTestBadProjectId, ErrorHandlingTestBase):
     pass

--- a/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/test_connection.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery_tests/ext/api/test_connection.py
@@ -31,7 +31,6 @@ class ErrorHandlingTestBase(BigQueryConnectionTestBase, ConnectionTestBase, Regu
         resp_data = resp.json
         assert "code" in resp_data, resp_data
         assert "message" in resp_data, resp_data
-        print(resp.json)
 
 
 class TestErrorHandlingMalformedCreds(BigQueryConnectionTestMalformedCreds, ErrorHandlingTestBase):

--- a/lib/dl_core/dl_core/exc.py
+++ b/lib/dl_core/dl_core/exc.py
@@ -56,6 +56,11 @@ class TableNameInvalidError(DataSourceConfigurationError):
     err_code = DataSourceConfigurationError.err_code + ["TABLE_NAME_INVALID"]
 
 
+class MalformedCredentialsError(DataSourceConfigurationError):
+    err_code = DataSourceConfigurationError.err_code + ["MALFORMED_CREDS"]
+    default_message = "Malformed credentials"
+
+
 class DatasetConfigurationError(DLBaseException):
     err_code = DLBaseException.err_code + ["DS_CONFIG"]
 


### PR DESCRIPTION
Also semi-fix test table setup (user type map, sqlalchemy types)

Also, there are a bunch of failing tests (e.g. `TestBigQueryDataCache` and most of `api/`), that could never be green because of the issues above and this https://github.com/datalens-tech/datalens-backend/blob/d467d405fafc7a17f113892f11a9f711e3d8cc2a/lib/dl_api_lib_testing/dl_api_lib_testing/helpers/data_source.py#L8-L8 comment in addition (data sources with connector specific fields can't be constructed properly)