### PR TITLE
fix: BI-5359 fix joining node normalization

### DIFF
--- a/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_ext_agg_basic.py
+++ b/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_ext_agg_basic.py
@@ -1041,3 +1041,25 @@ class TestBasicExtendedAggregations(DefaultApiTestBase, DefaultBasicExtAggregati
             fail_ok=True,
         )
         assert result_resp.status_code == HTTPStatus.BAD_REQUEST, result_resp.json
+
+    def test_include_with_array(self, control_api, data_api, saved_dataset):
+        ds = add_formulas_to_dataset(
+            api_v1=control_api,
+            dataset=saved_dataset,
+            formulas={
+                "array": "ARRAY([city], [category] + 'lol')",
+                "include": "SUM(SUM(SUM(1) INCLUDE [city]))",
+            },
+        )
+
+        result_resp = data_api.get_result(
+            dataset=ds,
+            fields=[
+                ds.find_field(title="array"),
+                ds.find_field(title="include"),
+            ],
+            fail_ok=True,
+        )
+        assert result_resp.status_code == HTTPStatus.OK, result_resp.json
+        data_rows = get_data_rows(result_resp)
+        assert len(data_rows) > 0


### PR DESCRIPTION
As a consequence of https://github.com/datalens-tech/datalens-backend/pull/620, it is now possible that when we are normalizing join nodes, we erroneously replace the child node instead of a parent. To resolve this, we should apply replacements one by one, and check for more complex replacements first. This way parent replacements would occur first.