### PR TITLE
test(connectors): BI-0 fix snowflake auth test once again

### DIFF
--- a/lib/dl_auth_api_lib/dl_auth_api_lib_tests/ext/test_snowflake.py
+++ b/lib/dl_auth_api_lib/dl_auth_api_lib_tests/ext/test_snowflake.py
@@ -24,7 +24,7 @@ async def test_snowflake_token(oauth_app_client, snowflake_payload):
 @pytest.mark.parametrize(
     "account,expected_resp_substring",
     [
-        ("bad-account", "513"),
+        ("bad-account", "unexpected response from an external API"),
         ("bad-account.eu-central-1", "unexpected response from an external API"),
         ("another.bad-account.eu-central-1", "certificate is not valid"),
     ],


### PR DESCRIPTION
The error that we receive from snowflake in case of invalid account has changed once again