### PR TITLE
test(connectors): BI-0 update filter in metrica tests

### DIFF
--- a/lib/dl_connector_metrica/dl_connector_metrica_tests/ext/api/test_data.py
+++ b/lib/dl_connector_metrica/dl_connector_metrica_tests/ext/api/test_data.py
@@ -42,7 +42,7 @@ class TestMetricaDataResult(MetricaDataApiTestBase, DefaultConnectorDataResultTe
                 ds.find_field(title="Просмотров в минуту"),
             ],
             filters=[
-                ds.find_field(title="Дата просмотра").filter("BETWEEN", values=["2019-12-01", "2019-12-07 12:00:00"])
+                ds.find_field(title="Дата просмотра").filter("BETWEEN", values=["2023-12-01", "2023-12-07 12:00:00"])
             ],
             order_by=[ds.find_field(title="Просмотров в минуту")],
             limit=3,


### PR DESCRIPTION
The current filter started to cause the following error
```
Date of beginning or end of accounting period entered incorrectly, value: 2019-12-01, limit: 2021-02-01, error code: 4005
```