### PR TITLE
fix(formula): BI-5959 apply mutations before adding formula to global dimensions during validation

### DIFF
--- a/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_window_functions.py
+++ b/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_window_functions.py
@@ -465,7 +465,6 @@ class TestBasicWindowFunctions(DefaultApiTestBase, DefaultBasicWindowFunctionTes
         data_rows = get_data_rows(result_resp)  # [['H1', '161667.14076359986'], ['H2', '228798.99612549983']]
         assert len(data_rows) == 2
 
-
     def test_order_by_multilevel_window_function(self, control_api, data_api, saved_dataset):
         ds = add_formulas_to_dataset(
             api_v1=control_api,

--- a/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_window_functions.py
+++ b/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/complex_queries/test_window_functions.py
@@ -443,7 +443,6 @@ class TestBasicWindowFunctions(DefaultApiTestBase, DefaultBasicWindowFunctionTes
                     ELSE "H2"
                     END
                 """,
-                # "order_period": "[quantity] + (1 - 1)",
                 "Group Sales": "SUM([sales])",
                 "RSum": "RSUM([Group Sales])",
             },

--- a/lib/dl_query_processing/dl_query_processing/compilation/formula_compiler.py
+++ b/lib/dl_query_processing/dl_query_processing/compilation/formula_compiler.py
@@ -868,7 +868,7 @@ class FormulaCompiler:
             for dim_field_id in self._group_by_ids:
                 dim_field = self._fields.get(id=dim_field_id)
                 try:
-                    dim_formula_obj = self._process_field_stage_aggregation(dim_field, collect_errors=collect_errors)
+                    dim_formula_obj = self._process_field_stage_mutation(dim_field, collect_errors=collect_errors)
                 except formula_exc.FormulaError:
                     # error has been registered, so when the field will be rendered explicitly the error will be raised
                     # here we can just skip it since there's nothing to register as a dimension


### PR DESCRIPTION
This change should also be virtually free in terms of performance thanks to stage caching https://github.com/datalens-tech/datalens-backend/blob/62ce5bf2b9a8f1d22c4a1342f72629037708dc28/lib/dl_query_processing/dl_query_processing/compilation/formula_compiler.py#L283-L290