### PR TITLE
feat(connectors): BI-5971 Migrate to new YDB dialect & dbapi to support QueryService

### DIFF
--- a/lib/dl_connector_ydb/dl_connector_ydb/core/base/type_transformer.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/base/type_transformer.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 import sqlalchemy as sa
-import ydb.sqlalchemy as ydb_sa
+import ydb_sqlalchemy as ydb_sa
 
 from dl_constants.enums import UserDataType
 from dl_type_transformer.type_transformer import (

--- a/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/adapter.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/adapter.py
@@ -11,7 +11,7 @@ from typing import (
 import attr
 import grpc
 from ydb import DriverConfig
-import ydb.dbapi as ydb_dbapi
+import ydb_dbapi
 from ydb.driver import credentials_impl
 import ydb.issues as ydb_cli_err
 

--- a/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/connector.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/connector.py
@@ -1,5 +1,3 @@
-from ydb.sqlalchemy import register_dialect as yql_register_dialect
-
 from dl_core.connectors.base.connector import (
     CoreBackendDefinition,
     CoreConnectionDefinition,
@@ -72,7 +70,3 @@ class YDBCoreConnector(CoreConnector):
         YDBCoreSubselectSourceDefinition,
     )
     rqe_adapter_classes = frozenset({YDBAdapter})
-
-    @classmethod
-    def registration_hook(cls) -> None:
-        yql_register_dialect()

--- a/lib/dl_connector_ydb/dl_connector_ydb/formula/connector.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/formula/connector.py
@@ -1,4 +1,4 @@
-from ydb.sqlalchemy import YqlDialect as SAYqlDialect
+from ydb_sqlalchemy import YqlDialect as SAYqlDialect
 
 from dl_formula.connectors.base.connector import FormulaConnector
 from dl_query_processing.compilation.query_mutator import RemoveConstFromGroupByFormulaAtomicQueryMutator

--- a/lib/dl_connector_ydb/dl_connector_ydb/formula/definitions/functions_aggregation.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/formula/definitions/functions_aggregation.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-import ydb.sqlalchemy as ydb_sa
+import ydb_sqlalchemy as ydb_sa
 
 from dl_formula.definitions.base import (
     TranslationVariant,

--- a/lib/dl_connector_ydb/dl_connector_ydb/formula/definitions/functions_string.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/formula/definitions/functions_string.py
@@ -1,5 +1,5 @@
 import sqlalchemy as sa
-import ydb.sqlalchemy as ydb_sa
+import ydb_sqlalchemy as ydb_sa
 
 from dl_formula.definitions.base import TranslationVariant
 from dl_formula.definitions.common import (

--- a/lib/dl_connector_ydb/docker-compose.yml
+++ b/lib/dl_connector_ydb/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   db-ydb:
-    image: "cr.yandex/yc/yandex-docker-local-ydb:latest"
+    image: "ydbplatform/local-ydb:trunk"
     environment:
       YDB_LOCAL_SURVIVE_RESTART: "true"
       GRPC_PORT: "51900"

--- a/lib/dl_connector_ydb/pyproject.toml
+++ b/lib/dl_connector_ydb/pyproject.toml
@@ -14,7 +14,9 @@ marshmallow = ">=3.19.0"
 python = ">=3.10, <3.13"
 sqlalchemy = ">=1.4.46, <2.0"
 typing-extensions = ">=4.9.0"
-ydb = ">=3.5.1"
+ydb = ">=3.18.10"
+ydb-sqlalchemy = ">=0.1.4"
+ydb-dbapi = ">=0.1.5"
 dl-api-commons = {path = "../dl_api_commons"}
 dl-api-connector = {path = "../dl_api_connector"}
 dl-configs = {path = "../dl_configs"}


### PR DESCRIPTION
RN DataLens uses legacy YDB DBAPI and SA Dialect. The new one uses YDB's QueryService, that is more flexible than previous one. 