### PR TITLE
test: BI-0 Force table name to be generated in lowercase in CsvTableDumper

### DIFF
--- a/lib/dl_connector_oracle/dl_connector_oracle_tests/db/core/test_connection_executor.py
+++ b/lib/dl_connector_oracle/dl_connector_oracle_tests/db/core/test_connection_executor.py
@@ -8,7 +8,15 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.oracle import base as oracle_types
 
 from dl_constants.enums import UserDataType
-from dl_core.connection_models.common_models import DBIdent
+from dl_core.connection_executors.sync_base import SyncConnExecutorBase
+from dl_core.connection_models.common_models import (
+    DBIdent,
+    SchemaIdent,
+)
+from dl_core_testing.database import (
+    Db,
+    DbTable,
+)
 from dl_core_testing.testcases.connection_executor import (
     DefaultAsyncConnectionExecutorTestSuite,
     DefaultSyncAsyncConnectionExecutorCheckBase,
@@ -75,6 +83,22 @@ class TestOracleSyncConnectionExecutor(
                 self.CD(oracle_types.TIMESTAMP(), UserDataType.genericdatetime),
             ],
         }
+
+    def test_get_table_names(
+        self,
+        sample_table: DbTable,
+        db: Db,
+        sync_connection_executor: SyncConnExecutorBase,
+    ) -> None:
+        # at the moment, checks that sample table is listed among the others
+
+        tables = [sample_table]
+        expected_table_names = set(table.name.upper() for table in tables)
+
+        actual_tables = sync_connection_executor.get_tables(SchemaIdent(db_name=db.name, schema_name=None))
+        actual_table_names = [tid.table_name for tid in actual_tables]
+
+        assert set(actual_table_names).issuperset(expected_table_names)
 
 
 class TestOracleAsyncConnectionExecutor(

--- a/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
+++ b/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
@@ -72,7 +72,7 @@ class CsvTableDumper:
         table_name_prefix = table_name_prefix or "table_"
         if not table_name_prefix.endswith("_"):
             table_name_prefix = f"{table_name_prefix}_"
-        table_name = f"{table_name_prefix}{shortuuid.uuid()}"
+        table_name = f"{table_name_prefix}{shortuuid.uuid()}".lower()
 
         type_schema = [user_type for col_name, user_type in table_schema]
         data = self._load_table_data(raw_csv_data=raw_csv_data, type_schema=type_schema)

--- a/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
+++ b/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
@@ -73,7 +73,7 @@ class CsvTableDumper:
         if not table_name_prefix.endswith("_"):
             table_name_prefix = f"{table_name_prefix}_"
         table_name = f"{table_name_prefix}{shortuuid.uuid()}".lower()
-        
+
         # TODO: This is a workaround for Oracle. Remove it when the issue is fixed.
         if self.db.config.conn_type.name == "oracle":
             table_name = table_name.upper()

--- a/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
+++ b/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
@@ -74,7 +74,7 @@ class CsvTableDumper:
             table_name_prefix = f"{table_name_prefix}_"
         table_name = f"{table_name_prefix}{shortuuid.uuid()}".lower()
 
-        # TODO: This is a workaround for Oracle. Remove it when the issue is fixed.
+        # TODO: BI-6104 This is a workaround for Oracle. Remove it when the issue is fixed.
         if self.db.config.conn_type.name == "oracle":
             table_name = table_name.upper()
 

--- a/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
+++ b/lib/dl_core_testing/dl_core_testing/csv_table_dumper.py
@@ -73,6 +73,10 @@ class CsvTableDumper:
         if not table_name_prefix.endswith("_"):
             table_name_prefix = f"{table_name_prefix}_"
         table_name = f"{table_name_prefix}{shortuuid.uuid()}".lower()
+        
+        # TODO: This is a workaround for Oracle. Remove it when the issue is fixed.
+        if self.db.config.conn_type.name == "oracle":
+            table_name = table_name.upper()
 
         type_schema = [user_type for col_name, user_type in table_schema]
         data = self._load_table_data(raw_csv_data=raw_csv_data, type_schema=type_schema)


### PR DESCRIPTION
Some DBMS do not support case-sensitive table names at all (MySQL is an example). However, using lowercase table names is always a good practice.