### PR TITLE
feat(optimization): BI-5933 avoid double deserialization for cached datasets

### DIFF
--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
@@ -110,6 +110,8 @@ class DatasetCollection(DatasetResource):
         loader = self.create_dataset_api_loader()
         loader.populate_dataset_from_body(dataset=dataset, body=body["dataset"], us_manager=us_manager)
 
+        ds_editor.set_revision_id(revision_id=generate_revision_id())
+
         us_manager.save(dataset)
 
         LOGGER.info("New dataset was saved with ID %s", dataset.uuid)
@@ -379,6 +381,7 @@ class DatasetImportCollection(DatasetResource):
         )
         ds_editor = DatasetComponentEditor(dataset=dataset)
 
+        ds_editor.set_revision_id(revision_id=generate_revision_id())
         ds_editor.set_created_via(created_via=DataSourceCreatedVia.workbook_copy)
 
         result_schema = data["dataset"].get("result_schema", [])

--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
@@ -381,7 +381,6 @@ class DatasetImportCollection(DatasetResource):
         )
         ds_editor = DatasetComponentEditor(dataset=dataset)
 
-        ds_editor.set_revision_id(revision_id=generate_revision_id())
         ds_editor.set_created_via(created_via=DataSourceCreatedVia.workbook_copy)
 
         result_schema = data["dataset"].get("result_schema", [])
@@ -390,6 +389,8 @@ class DatasetImportCollection(DatasetResource):
 
         loader = self.create_dataset_api_loader()
         loader.populate_dataset_from_body(dataset=dataset, body=data["dataset"], us_manager=us_manager)
+
+        ds_editor.set_revision_id(revision_id=generate_revision_id())
 
         us_manager.save(dataset)
 

--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
@@ -110,8 +110,6 @@ class DatasetCollection(DatasetResource):
         loader = self.create_dataset_api_loader()
         loader.populate_dataset_from_body(dataset=dataset, body=body["dataset"], us_manager=us_manager)
 
-        ds_editor.set_revision_id(revision_id=generate_revision_id())
-
         us_manager.save(dataset)
 
         LOGGER.info("New dataset was saved with ID %s", dataset.uuid)
@@ -389,8 +387,6 @@ class DatasetImportCollection(DatasetResource):
 
         loader = self.create_dataset_api_loader()
         loader.populate_dataset_from_body(dataset=dataset, body=data["dataset"], us_manager=us_manager)
-
-        ds_editor.set_revision_id(revision_id=generate_revision_id())
 
         us_manager.save(dataset)
 

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -348,7 +348,7 @@ class DatasetDataBaseView(BaseView):
         self,
         mutation_cache: Optional[USEntryMutationCache],
         mutation_key: Optional[MutationKey],
-    ) -> Optional[Dataset]:
+    ) -> Optional[Dataset]:  # type: ignore  # TODO: fix
         cached_dataset = await self.try_get_dataset_from_cache_by_id(
             self.dataset_id,
             self.dataset.revision_id,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -295,6 +295,7 @@ class DatasetDataBaseView(BaseView):
             raise web.HTTPNotFound(reason="Entity not found") from e
 
         # TODO: Try using partial deserialization instead of direct dict lookup if possible
+        assert us_resp is not None
         revision_id = us_resp["data"]["revision_id"]
         permissions = us_resp.get("permissions", None)
         permissions_mode = us_resp.get("permissions_mode", None)
@@ -323,7 +324,6 @@ class DatasetDataBaseView(BaseView):
                 self.dataset.permissions = permissions
                 self.dataset.permissions_mode = permissions_mode
             else:
-                assert us_resp is not None
                 dataset = await us_manager.deserialize_us_resp(us_resp, Dataset)
                 assert isinstance(dataset, Dataset)
 
@@ -360,11 +360,10 @@ class DatasetDataBaseView(BaseView):
                 req_model=req_model,
                 allow_rls_change=allow_rls_change,
             )
-        else:
-            return await self._prepare_dataset_from_cache_with_dataset_id(
-                req_model=req_model,
-                allow_rls_change=allow_rls_change,
-            )
+        return await self._prepare_dataset_from_cache_with_dataset_id(
+            req_model=req_model,
+            allow_rls_change=allow_rls_change,
+        )
 
     @staticmethod
     def _updates_only_fields(updates: List[Action]) -> bool:

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -306,6 +306,7 @@ class DatasetDataBaseView(BaseView):
 
         with GenericProfiler("dataset-prepare"):
             # Try from cache
+            cached_dataset = None
             if enable_mutation_caching:
                 mutation_cache = self.try_get_cache(allow_slave=False)
                 # TODO consider: ^ analyze profiling & maybe use allow_slave=True when reading from cache

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -175,6 +175,7 @@ class DatasetDataBaseView(BaseView):
         capabilities = DatasetCapabilities(dataset=dataset, dsrc_coll_factory=dsrc_coll_factory)
         return capabilities.resolve_source_role(log_reasons=log_reasons)
 
+    @generic_profiler_async("resolve-entities")
     async def resolve_entities(self) -> None:
         us_manager = self.dl_request.us_manager
         if self.dl_request.log_ctx_controller:

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -175,7 +175,7 @@ class DatasetDataBaseView(BaseView):
         capabilities = DatasetCapabilities(dataset=dataset, dsrc_coll_factory=dsrc_coll_factory)
         return capabilities.resolve_source_role(log_reasons=log_reasons)
 
-    @generic_profiler_async("resolve-entities")
+    @generic_profiler_async("resolve-entities")  # type: ignore  # TODO: fix
     async def resolve_entities(self) -> None:
         us_manager = self.dl_request.us_manager
         if self.dl_request.log_ctx_controller:
@@ -200,7 +200,7 @@ class DatasetDataBaseView(BaseView):
         self.dataset = dataset
         self.ds_accessor = DatasetComponentAccessor(dataset=dataset)
 
-    @generic_profiler_async("prepare-dataset-with-mutation-cache")
+    @generic_profiler_async("prepare-dataset-with-mutation-cache")  # type: ignore  # TODO: fix
     async def prepare_dataset_with_mutation_cache(
         self,
         req_model: DataRequestModel,
@@ -365,8 +365,8 @@ class DatasetDataBaseView(BaseView):
 
         return cached_dataset
 
-    @staticmethod
-    @generic_profiler_async("mutation-cache-get")  # type: ignore  # TODO: fix
+    @staticmethod  # type: ignore  # TODO: fix
+    @generic_profiler_async("mutation-cache-get")
     async def try_get_dataset_from_cache_by_id(
         dataset_id: Optional[str],
         revision_id: Optional[str],

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -223,8 +223,8 @@ class DatasetDataBaseView(BaseView):
             )
 
             revision_id = dataset.revision_id
-            permission = dataset.permissions
-            permission_mode = dataset.permissions_mode
+            permission = dataset.permissions  # noqa
+            permission_mode = dataset.permissions_mode  # noqa
         else:  # case 2
             try:
                 dataset = None
@@ -273,7 +273,7 @@ class DatasetDataBaseView(BaseView):
                 if self.dataset_id is None:  # case 1
                     self.datset = dataset
                 else:
-                    self.dataset = await us_manager.deserialize_us_resp(us_resp, Dataset)
+                    self.dataset = await us_manager.deserialize_us_resp(us_resp, Dataset)  # type: ignore  # TODO: fix
 
                     await us_manager.load_dependencies(self.dataset)
 
@@ -318,7 +318,9 @@ class DatasetDataBaseView(BaseView):
         return self.try_get_mutation_key_for_dataset(self.dataset_id, self.dataset.revision_id, updates)
 
     @staticmethod
-    def try_get_mutation_key_for_dataset(dataset_id: Optional[str], revision_id: Optional[str], updates: List[Action]) -> Optional[MutationKey]:
+    def try_get_mutation_key_for_dataset(
+        dataset_id: Optional[str], revision_id: Optional[str], updates: List[Action]
+    ) -> Optional[MutationKey]:
         if dataset_id is not None and revision_id is not None:
             if DatasetDataBaseView._updates_only_fields(updates):
                 return UpdateDatasetMutationKey.create(revision_id, updates)  # type: ignore  # 2024-01-30 # TODO: Argument 2 to "create" of "UpdateDatasetMutationKey" has incompatible type "list[Action]"; expected "list[FieldAction]"  [arg-type]
@@ -347,7 +349,7 @@ class DatasetDataBaseView(BaseView):
         mutation_cache: Optional[USEntryMutationCache],
         mutation_key: Optional[MutationKey],
     ) -> Optional[Dataset]:
-        cached_dataset = self.try_get_dataset_from_cache_by_id(
+        cached_dataset = await self.try_get_dataset_from_cache_by_id(
             self.dataset_id,
             self.dataset.revision_id,
             mutation_cache,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -271,9 +271,14 @@ class DatasetDataBaseView(BaseView):
             # Forced to deserialize
             else:
                 if self.dataset_id is None:  # case 1
-                    self.dataset = dataset  # type: ignore  # TODO: fix
-                else:
-                    self.dataset = await us_manager.deserialize_us_resp(us_resp, Dataset)  # type: ignore  # TODO: fix
+                    assert dataset is not None
+                    self.dataset = dataset
+                else:  # case 2
+                    assert us_resp is not None
+                    dataset_entry = await us_manager.deserialize_us_resp(us_resp, Dataset)
+                    assert isinstance(dataset_entry, Dataset)
+
+                    self.dataset = dataset_entry
 
                     await us_manager.load_dependencies(self.dataset)
 
@@ -348,7 +353,7 @@ class DatasetDataBaseView(BaseView):
         self,
         mutation_cache: Optional[USEntryMutationCache],
         mutation_key: Optional[MutationKey],
-    ) -> Optional[Dataset]:  # type: ignore  # TODO: fix
+    ) -> Optional[Dataset]:
         cached_dataset = await self.try_get_dataset_from_cache_by_id(
             self.dataset_id,
             self.dataset.revision_id,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -232,7 +232,7 @@ class DatasetDataBaseView(BaseView):
             except USObjectNotFoundException as e:
                 raise web.HTTPNotFound(reason="Entity not found") from e
 
-            # Very bad
+            # TODO: Try using partial deserialization instead of direct dict lookup if possible
             revision_id = us_resp["data"]["revision_id"]
             permissions = us_resp.get("permissions", None)
             permissions_mode = us_resp.get("permissions_mode", None)
@@ -271,7 +271,7 @@ class DatasetDataBaseView(BaseView):
             # Forced to deserialize
             else:
                 if self.dataset_id is None:  # case 1
-                    self.datset = dataset
+                    self.dataset = dataset  # type: ignore  # TODO: fix
                 else:
                     self.dataset = await us_manager.deserialize_us_resp(us_resp, Dataset)  # type: ignore  # TODO: fix
 

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/distinct.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/distinct.py
@@ -42,14 +42,11 @@ class DatasetDistinctView(DatasetDataBaseView, abc.ABC):
     #     responses={200: ('Success', dl_api_lib.schemas.data.DatasetVersionValuesDistinctResponseSchema())}
     # )
     @generic_profiler_async("ds-values-distinct-full")
-    @DatasetDataBaseView.with_resolved_entities
     @requires(RequiredResourceDSAPI.JSON_REQUEST)
     async def post(self) -> Response:
         req_model: DataRequestModel = self.load_req_model()
-        self.check_dataset_revision_id(req_model)
 
-        enable_mutation_caching = self.dl_request.services_registry.get_mutation_cache_factory() is not None
-        await self.prepare_dataset_for_request(req_model=req_model, enable_mutation_caching=enable_mutation_caching)
+        await self.prepare_dataset_with_mutation_cache(req_model=req_model)
 
         merged_stream = await self.execute_all_queries(
             raw_query_spec_union=req_model.raw_query_spec_union,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/pivot.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/pivot.py
@@ -48,7 +48,6 @@ class DatasetPivotView(DatasetDataBaseView):
     #     responses={200: ('Success', dl_api_lib.schemas.data.DatasetVersionResultResponseSchema())}
     # )
     @generic_profiler_async("ds-pivot-full")
-    @DatasetDataBaseView.with_resolved_entities
     @requires(RequiredResourceDSAPI.JSON_REQUEST)
     async def post(self) -> Response:
         schema = dl_api_lib.schemas.data.PivotDataRequestBaseSchema()
@@ -57,8 +56,7 @@ class DatasetPivotView(DatasetDataBaseView):
         req_normalizer = PivotRequestModelNormalizer()
         req_model = req_normalizer.normalize_drm(req_model)
 
-        enable_mutation_caching = self.dl_request.services_registry.get_mutation_cache_factory() is not None
-        await self.prepare_dataset_for_request(req_model=req_model, enable_mutation_caching=enable_mutation_caching)
+        await self.prepare_dataset_with_mutation_cache(req_model=req_model)
 
         merged_stream = await self.execute_all_queries(
             raw_query_spec_union=req_model.raw_query_spec_union,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/range.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/range.py
@@ -55,14 +55,11 @@ class DatasetRangeView(DatasetDataBaseView, abc.ABC):
     #     responses={200: ('Success', dl_api_lib.schemas.data.DatasetVersionValuesRangeResponseSchema())}
     # )
     @generic_profiler_async("ds-values-range-full")
-    @DatasetDataBaseView.with_resolved_entities
     @requires(RequiredResourceDSAPI.JSON_REQUEST)
     async def post(self) -> Response:
         req_model = self.load_req_model()
-        self.check_dataset_revision_id(req_model)
 
-        enable_mutation_caching = self.dl_request.services_registry.get_mutation_cache_factory() is not None
-        await self.prepare_dataset_for_request(req_model=req_model, enable_mutation_caching=enable_mutation_caching)
+        await self.prepare_dataset_with_mutation_cache(req_model=req_model)
 
         merged_stream = await self.execute_all_queries(
             raw_query_spec_union=req_model.raw_query_spec_union,

--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/result.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/result.py
@@ -67,14 +67,11 @@ class DatasetResultView(DatasetDataBaseView, abc.ABC):
     #     responses={200: ('Success', dl_api_lib.schemas.data.DatasetVersionResultResponseSchema())}
     # )
     @generic_profiler_async("ds-result-full")
-    @DatasetDataBaseView.with_resolved_entities
     @requires(RequiredResourceDSAPI.JSON_REQUEST)
     async def post(self) -> Response:
         req_model = self.load_req_model()
-        self.check_dataset_revision_id(req_model)
 
-        enable_mutation_caching = self.dl_request.services_registry.get_mutation_cache_factory() is not None
-        await self.prepare_dataset_for_request(req_model=req_model, enable_mutation_caching=enable_mutation_caching)
+        await self.prepare_dataset_with_mutation_cache(req_model=req_model)
 
         merged_stream = await self.execute_all_queries(
             raw_query_spec_union=req_model.raw_query_spec_union,

--- a/lib/dl_core/dl_core/us_manager/us_entry_serializer.py
+++ b/lib/dl_core/dl_core/us_manager/us_entry_serializer.py
@@ -18,6 +18,10 @@ from typing import ChainMap as ChainMapGeneric
 import attr
 import marshmallow
 
+from dl_app_tools.profiling_base import (
+    GenericProfiler,
+    generic_profiler,
+)
 from dl_core.base_models import BaseAttrsDataModel
 from dl_core.us_dataset import Dataset
 from dl_core.us_entry import USEntry
@@ -93,6 +97,7 @@ class USEntrySerializer(abc.ABC):
     def get_data_attr(self, entry: USEntry, key: DataKey) -> Any:
         raise NotImplementedError()
 
+    @generic_profiler("us-serialize")
     def serialize(self, obj: USEntry) -> USDataPack:
         raw_dict = self.serialize_raw(obj)
 
@@ -110,6 +115,7 @@ class USEntrySerializer(abc.ABC):
             secrets=secrets_addressable.data,
         )
 
+    @generic_profiler("us-deserialize")
     def deserialize(
         self,
         cls: Type[USEntry],
@@ -133,7 +139,8 @@ class USEntrySerializer(abc.ABC):
         if secret_source_addressable.data:
             LOGGER.warning("Undeclared secrets found")
 
-        return self.deserialize_raw(cls, raw_addressable.data, entry_id, us_manager, common_properties, data_strict)
+        with GenericProfiler("us-deserialize-raw"):
+            return self.deserialize_raw(cls, raw_addressable.data, entry_id, us_manager, common_properties, data_strict)
 
 
 class USEntrySerializerMarshmallow(USEntrySerializer):

--- a/lib/dl_core/dl_core/us_manager/us_manager.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager.py
@@ -26,10 +26,7 @@ from dl_api_commons.base_models import (
     RequestContextInfo,
     TenantDef,
 )
-from dl_app_tools.profiling_base import (
-    GenericProfiler,
-    generic_profiler,
-)
+from dl_app_tools.profiling_base import generic_profiler
 from dl_configs.crypto_keys import (
     CryptoKeysConfig,
     get_crypto_keys_config_from_env,
@@ -369,12 +366,11 @@ class USManagerBase:
                 secrets=secrets,
             )
 
-            with GenericProfiler("us-deserialize-secrets"):
-                data_pack = copy.deepcopy(data_pack)
-                if data_pack.secrets:
-                    for key, secret in data_pack.secrets.items():
-                        assert not isinstance(secret, str)
-                        data_pack.secrets[key] = self._crypto_controller.decrypt(secret)
+            data_pack = copy.deepcopy(data_pack)
+            if data_pack.secrets:
+                for key, secret in data_pack.secrets.items():
+                    assert not isinstance(secret, str)
+                    data_pack.secrets[key] = self._crypto_controller.decrypt(secret)
 
             serializer = self.get_us_entry_serializer(entry_cls)
             entry = serializer.deserialize(

--- a/lib/dl_core/dl_core/us_manager/us_manager_async.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_async.py
@@ -180,7 +180,7 @@ class AsyncUSManager(USManagerBase):
 
         return obj
 
-    @generic_profiler_async("us-get-migrated-entity")
+    @generic_profiler_async("us-get-migrated-entity")  # type: ignore  # TODO: fix
     async def get_migrated_entry(self, entry_id: str, params: Optional[dict[str, str]] = None) -> dict[str, Any]:
         us_resp = await self._us_client.get_entry(entry_id, params=params)
         return await self._migrate_response(us_resp)
@@ -317,7 +317,7 @@ class AsyncUSManager(USManagerBase):
             raise ValueError("Entry was in cache but it is not a connection: %s", type(conn))
 
     # TODO FIX: Think about cache control
-    @generic_profiler_async("us-load-dependencies")
+    @generic_profiler_async("us-load-dependencies")  # type: ignore  # TODO: fix
     async def load_dependencies(self, entry: USEntry) -> None:
         if not isinstance(entry, Dataset):
             raise NotImplementedError("Links loading is supported only for dataset")
@@ -402,7 +402,7 @@ class AsyncUSManager(USManagerBase):
         async for us_resp in us_entry_iterator:
             try:
                 us_resp = await self._migrate_response(us_resp)
-                yield self._entry_dict_to_obj(us_resp, expected_type=entry_cls)  # type: ignore  # TODO: fix
+                yield self._entry_dict_to_obj(us_resp, expected_type=entry_cls)
             except Exception:
                 LOGGER.exception("Failed to load US object: %s", us_resp)
                 if raise_on_broken_entry:

--- a/lib/dl_core/dl_core/us_manager/us_manager_async.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_async.py
@@ -16,10 +16,7 @@ from typing import (
 )
 
 from dl_api_commons.base_models import RequestContextInfo
-from dl_app_tools.profiling_base import (
-    GenericProfiler,
-    generic_profiler_async,
-)
+from dl_app_tools.profiling_base import generic_profiler_async
 from dl_configs.crypto_keys import CryptoKeysConfig
 from dl_core import exc
 from dl_core.base_models import (
@@ -149,8 +146,7 @@ class AsyncUSManager(USManagerBase):
             us_resp = await self.get_migrated_entry(entry_id, params=params)
 
         obj = self._entry_dict_to_obj(us_resp, expected_type)
-        with GenericProfiler("us-fetch-post-init-hook"):
-            await self.get_lifecycle_manager(entry=obj).post_init_async_hook()
+        await self.get_lifecycle_manager(entry=obj).post_init_async_hook()
 
         return obj
 
@@ -180,8 +176,7 @@ class AsyncUSManager(USManagerBase):
         """Used on result of `get_by_id_raw()` call for proper deserialization flow"""
 
         obj = self._entry_dict_to_obj(us_resp, expected_type)
-        with GenericProfiler("us-fetch-post-init-hook"):
-            await self.get_lifecycle_manager(entry=obj).post_init_async_hook()
+        await self.get_lifecycle_manager(entry=obj).post_init_async_hook()
 
         return obj
 
@@ -190,7 +185,6 @@ class AsyncUSManager(USManagerBase):
         us_resp = await self._us_client.get_entry(entry_id, params=params)
         return await self._migrate_response(us_resp)
 
-    @generic_profiler_async("us-migrate-response")
     async def _migrate_response(self, us_resp: dict) -> dict:
         initial_type = us_resp["type"]
         while True:

--- a/lib/dl_core/dl_core/us_manager/us_manager_async.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_async.py
@@ -161,7 +161,7 @@ class AsyncUSManager(USManagerBase):
         expected_type: Optional[Type[USEntry]] = None,
         params: Optional[dict[str, str]] = None,
     ) -> dict[str, Any]:
-        """Get raw `u_resp` from response without deserialization"""
+        """Get raw `us_resp` from response without deserialization"""
 
         with self._enrich_us_exception(
             entry_id=entry_id,

--- a/lib/dl_core/dl_core/us_manager/us_manager_sync.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_sync.py
@@ -205,10 +205,12 @@ class SyncUSManager(USManagerBase):
 
         return obj
 
+    @generic_profiler("us-get-migrated-entity")
     def get_migrated_entry(self, entry_id: str, params: Optional[dict[str, str]] = None) -> dict[str, Any]:
         us_resp = self._us_client.get_entry(entry_id, params=params)
         return self._migrate_response(us_resp)
 
+    @generic_profiler("us-migrate-response")
     def _migrate_response(self, us_resp: dict) -> dict:
         initial_type = us_resp["type"]
         while True:
@@ -399,6 +401,7 @@ class SyncUSManager(USManagerBase):
             raise ValueError("Entry was in cache but it is not a connection: %s", type(conn))
 
     # TODO FIX: Think about cache control
+    @generic_profiler("us-load-dependencies")
     def load_dependencies(self, entry: USEntry) -> None:
         if not isinstance(entry, Dataset):
             raise NotImplementedError("Links loading is supported only for dataset")

--- a/lib/dl_core/dl_core/us_manager/us_manager_sync.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_sync.py
@@ -19,10 +19,7 @@ from typing import (
 from typing_extensions import Self
 
 from dl_api_commons.base_models import RequestContextInfo
-from dl_app_tools.profiling_base import (
-    GenericProfiler,
-    generic_profiler,
-)
+from dl_app_tools.profiling_base import generic_profiler
 from dl_configs.crypto_keys import CryptoKeysConfig
 from dl_core import exc
 from dl_core.base_models import (
@@ -204,8 +201,7 @@ class SyncUSManager(USManagerBase):
             us_resp = self.get_migrated_entry(entry_id, params=params)
 
         obj = self._entry_dict_to_obj(us_resp, expected_type)
-        with GenericProfiler("us-fetch-post-init-hook"):
-            await_sync(self.get_lifecycle_manager(entry=obj).post_init_async_hook())
+        await_sync(self.get_lifecycle_manager(entry=obj).post_init_async_hook())
 
         return obj
 
@@ -226,7 +222,7 @@ class SyncUSManager(USManagerBase):
 
         return us_resp
 
-    @generic_profiler("us-fetch-entity-raw")  # type: ignore  # TODO: fix
+    @generic_profiler("us-deserialize-entity-raw")  # type: ignore  # TODO: fix
     def deserialize_us_resp(
         self,
         us_resp: dict[str, Any],
@@ -235,8 +231,7 @@ class SyncUSManager(USManagerBase):
         """Used on result of `get_by_id_raw()` call for proper deserialization flow"""
 
         obj = self._entry_dict_to_obj(us_resp, expected_type)
-        with GenericProfiler("us-fetch-post-init-hook"):
-            await_sync(self.get_lifecycle_manager(entry=obj).post_init_async_hook())
+        await_sync(self.get_lifecycle_manager(entry=obj).post_init_async_hook())
 
         return obj
 
@@ -245,7 +240,6 @@ class SyncUSManager(USManagerBase):
         us_resp = self._us_client.get_entry(entry_id, params=params)
         return self._migrate_response(us_resp)
 
-    @generic_profiler("us-migrate-response")
     def _migrate_response(self, us_resp: dict) -> dict:
         initial_type = us_resp["type"]
         while True:

--- a/lib/dl_core/dl_core/us_manager/us_manager_sync.py
+++ b/lib/dl_core/dl_core/us_manager/us_manager_sync.py
@@ -205,7 +205,7 @@ class SyncUSManager(USManagerBase):
 
         return obj
 
-    @generic_profiler("us-fetch-entity-raw")  # type: ignore  # TODO: fix
+    @generic_profiler("us-fetch-entity-raw")
     def get_by_id_raw(
         self,
         entry_id: str,
@@ -222,7 +222,7 @@ class SyncUSManager(USManagerBase):
 
         return us_resp
 
-    @generic_profiler("us-deserialize-entity-raw")  # type: ignore  # TODO: fix
+    @generic_profiler("us-deserialize-entity-raw")
     def deserialize_us_resp(
         self,
         us_resp: dict[str, Any],
@@ -303,7 +303,7 @@ class SyncUSManager(USManagerBase):
         for us_resp in us_entry_iterator:
             try:
                 us_resp = self._migrate_response(us_resp)
-                yield self._entry_dict_to_obj(us_resp, expected_type=entry_cls)  # type: ignore  # TODO: fix
+                yield self._entry_dict_to_obj(us_resp, expected_type=entry_cls)
             except Exception:
                 LOGGER.exception("Failed to load US object: %s", us_resp)
                 if raise_on_broken_entry:


### PR DESCRIPTION
Feature explaination:

When mutations cache is used, dataset is being deserialized twice. 
First - in [resolve_entities decorator](https://github.com/datalens-tech/datalens-backend/blob/0be009e18142fd17e24ff7ff2fd5bcd767a9d6ca/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py#L178) inside [us manager get_by_id](https://github.com/datalens-tech/datalens-backend/blob/0be009e18142fd17e24ff7ff2fd5bcd767a9d6ca/lib/dl_core/dl_core/us_manager/us_manager_async.py#L148) 
Second - in [prepare_dataset_for_request](https://github.com/datalens-tech/datalens-backend/blob/0be009e18142fd17e24ff7ff2fd5bcd767a9d6ca/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py#L288) when deserializing object from cache.

In real world case, deserialization may take up to 300 (or more) milliseconds, doubled to 600+ms in endpoint.

This PR implements mixed logic inside of `prepare_dataset_with_mutation_cache` by splitting behavior of `resolve_entities` and `prepare_dataset_for_request`:
- When trying to resolve dataset, request is made to US service (`resolve_entities` code is performed until (inclusive) the [us_request](https://github.com/datalens-tech/datalens-backend/blob/0be009e18142fd17e24ff7ff2fd5bcd767a9d6ca/lib/dl_core/dl_core/us_manager/us_manager_sync.py#L201))
- `revision_id`, `permissions_mode`, `permission` are extracted directly from raw response dict
- `revision_id` is used to check against revision in request body and try to get dataset from cache
- If required revision exists in cache, cached version is returned (and `load_dependencies` is called to ensure that all connections data is cached)
- In another case, second part of `resolve_entities` is performed: `resolve_entities` code continues starting from [deserialization inside of us manager](https://github.com/datalens-tech/datalens-backend/blob/0be009e18142fd17e24ff7ff2fd5bcd767a9d6ca/lib/dl_core/dl_core/us_manager/us_manager_sync.py#L203)

As result, dataset is deserialized in case when there is no cache, cache is used if there is cache and deserialization takes place only once.