### PR TITLE
fix: BI-5355 Move Trino get_catalogs query from adapter to us_connection

### DIFF
--- a/lib/dl_connector_trino/dl_connector_trino/core/adapters.py
+++ b/lib/dl_connector_trino/dl_connector_trino/core/adapters.py
@@ -14,7 +14,6 @@ from trino.auth import (
 )
 from trino.sqlalchemy import URL as trino_url
 from trino.sqlalchemy.datatype import parse_sqltype
-from trino.sqlalchemy.dialect import TrinoDialect
 
 from dl_core.connection_executors.adapters.adapters_base_sa_classic import BaseClassicAdapter
 from dl_core.connection_executors.models.db_adapter_data import DBAdapterQuery
@@ -33,13 +32,6 @@ from dl_connector_trino.core.constants import (
 from dl_connector_trino.core.error_transformer import trino_error_transformer
 from dl_connector_trino.core.target_dto import TrinoConnTargetDTO
 
-
-TRINO_SYSTEM_CATALOGS = (
-    "system",
-    "tpch",
-    "tpcds",
-    "jmx",
-)
 
 TRINO_SYSTEM_SCHEMAS = ("information_schema",)
 
@@ -126,11 +118,6 @@ class TrinoDefaultAdapter(BaseClassicAdapter[TrinoConnTargetDTO]):
     def _get_db_version(self, db_ident: DBIdent) -> str:
         dialect = self.get_dialect()
         return dialect.server_version_info[0]
-
-    def get_catalog_names(self) -> list[str]:
-        dialect: TrinoDialect = self.get_dialect()
-        with self.get_db_engine(db_name=None).connect() as conn:
-            return [catalog for catalog in dialect.get_catalog_names(conn) if catalog not in TRINO_SYSTEM_CATALOGS]
 
     def _get_tables(self, schema_ident: SchemaIdent) -> list[TableIdent]:
         """

--- a/lib/dl_connector_trino/dl_connector_trino/core/us_connection.py
+++ b/lib/dl_connector_trino/dl_connector_trino/core/us_connection.py
@@ -2,20 +2,20 @@ from typing import (
     Callable,
     ClassVar,
     Optional,
-    cast,
 )
 
 import attr
+import sqlalchemy as sa
+from trino.sqlalchemy.dialect import TrinoDialect
 
 from dl_core.connection_executors import SyncConnExecutorBase
-from dl_core.connection_executors.sync_executor_wrapper import SyncWrapperForAsyncConnExecutor
+from dl_core.connection_executors.common_base import ConnExecutorQuery
 from dl_core.us_connection_base import (
     ConnectionBase,
     ConnectionSQL,
 )
 from dl_core.utils import secrepr
 
-from dl_connector_trino.core.adapters import TrinoDefaultAdapter
 from dl_connector_trino.core.constants import (
     CONNECTION_TYPE_TRINO,
     SOURCE_TYPE_TRINO_SUBSELECT,
@@ -23,6 +23,33 @@ from dl_connector_trino.core.constants import (
     TrinoAuthType,
 )
 from dl_connector_trino.core.dto import TrinoConnDTO
+
+
+TRINO_SYSTEM_CATALOGS = (
+    "system",
+    "tpch",
+    "tpcds",
+    "jmx",
+)
+
+TRINO_CATALOGS = sa.Table(
+    "catalogs",
+    sa.MetaData(),
+    sa.Column("table_cat", sa.String),
+    schema="jdbc",
+)
+GET_TRINO_CATALOGS_QUERY = str(
+    sa.select(
+        TRINO_CATALOGS.c.table_cat,
+    )
+    .where(
+        ~TRINO_CATALOGS.c.table_cat.in_(TRINO_SYSTEM_CATALOGS),
+    )
+    .order_by(
+        TRINO_CATALOGS.c.table_cat,
+    )
+    .compile(dialect=TrinoDialect(), compile_kwargs={"literal_binds": True})
+)
 
 
 class ConnectionTrino(ConnectionSQL):
@@ -53,25 +80,15 @@ class ConnectionTrino(ConnectionSQL):
             ssl_ca=self.data.ssl_ca,
         )
 
-    def get_catalog_names(
-        self,
-        conn_executor_factory: Callable[[ConnectionBase], SyncConnExecutorBase],
-    ) -> list[str]:
-        # It is impossible to define `get_catalog_names` in `TrinoConnExecutor` and call it from here
-        # because `conn_executor_factory` returns `SyncWrapperForAsyncConnExecutor`, not `TrinoConnExecutor` (surprise!).
-        # So, `SyncWrapperForAsyncConnExecutor` sets a set of methods that can be defined in `TrinoConnExecutor`.
-        # To keep source querying logic in `Adapter`, we need this hack with `_extract_sync_sa_adapter`.
-        conn_executor = cast(SyncWrapperForAsyncConnExecutor, conn_executor_factory(self))
-        sa_adapter = cast(TrinoDefaultAdapter, conn_executor._extract_sync_sa_adapter(raise_on_not_exists=True))
-        return sa_adapter.get_catalog_names()
-
     def get_parameter_combinations(
         self,
         conn_executor_factory: Callable[[ConnectionBase], SyncConnExecutorBase],
     ) -> list[dict]:
         parameter_combinations: list[dict] = []
-        catalog_names = self.get_catalog_names(conn_executor_factory=conn_executor_factory)
-        for catalog_name in catalog_names:
+        conn_executor = conn_executor_factory(self)
+        catalogs_query = ConnExecutorQuery(query=GET_TRINO_CATALOGS_QUERY, db_name="system")
+        for catalog_row in conn_executor.execute(query=catalogs_query).get_all():
+            catalog_name = catalog_row[0]
             tables = self.get_tables(conn_executor_factory=conn_executor_factory, db_name=catalog_name)
             parameter_combinations.extend(
                 dict(

--- a/lib/dl_connector_trino/dl_connector_trino_tests/db/core/test_connection.py
+++ b/lib/dl_connector_trino/dl_connector_trino_tests/db/core/test_connection.py
@@ -1,12 +1,12 @@
 from dl_core.us_connection_base import DataSourceTemplate
 from dl_core_testing.testcases.connection import DefaultConnectionTestClass
 
-from dl_connector_trino.core.adapters import (
-    TRINO_SYSTEM_CATALOGS,
-    TRINO_SYSTEM_SCHEMAS,
-)
+from dl_connector_trino.core.adapters import TRINO_SYSTEM_SCHEMAS
 from dl_connector_trino.core.constants import TrinoAuthType
-from dl_connector_trino.core.us_connection import ConnectionTrino
+from dl_connector_trino.core.us_connection import (
+    TRINO_SYSTEM_CATALOGS,
+    ConnectionTrino,
+)
 from dl_connector_trino_tests.db.core.base import (
     BaseTrinoJwtTestClass,
     BaseTrinoPasswordTestClass,


### PR DESCRIPTION
This is important because `conn_executor._extract_sync_sa_adapter` hack doesn't work for RQE