### PR TITLE
feat: BI-6218 rev_id query param for data-api

### DIFF
--- a/lib/dl_api_client/dl_api_client/dsmaker/api/data_api.py
+++ b/lib/dl_api_client/dl_api_client/dsmaker/api/data_api.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 import typing
+import urllib.parse
 
 import attr
 
@@ -696,8 +697,11 @@ class SyncHttpDataApiV2(SyncHttpDataApiBase):
         dataset_id: str,
         raw_body: dict,
         headers: dict | None = None,
+        query_params: dict[str, str] | None = None,
     ) -> ClientResponse:
         url = f"/api/data/{self.api_v}/datasets/{dataset_id}/result"
+        if query_params:
+            url += "?" + urllib.parse.urlencode(query_params)
         return self._request(url, method="post", data=raw_body, headers=headers)
 
     def get_response_for_dataset_value_range(
@@ -770,6 +774,7 @@ class SyncHttpDataApiV2(SyncHttpDataApiBase):
         ignore_nonexistent_filters: bool | None = None,
         row_count_hard_limit: int | None = None,
         fail_ok: bool = False,
+        query_params: dict[str, str] | None = None,
     ) -> HttpDataApiResponse:
         data = self.serial_adapter.make_req_data_get_result(
             dataset=dataset,
@@ -787,7 +792,7 @@ class SyncHttpDataApiV2(SyncHttpDataApiBase):
             row_count_hard_limit=row_count_hard_limit,
             updates=updates,
         )
-        response = self.get_response_for_dataset_result(dataset_id=dataset.id, raw_body=data)
+        response = self.get_response_for_dataset_result(dataset_id=dataset.id, raw_body=data, query_params=query_params)
         resp_data: dict | None = None
         if not fail_ok:
             assert response.status_code == HTTPStatus.OK, response.json

--- a/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/test_revision.py
+++ b/lib/dl_api_lib/dl_api_lib_tests/db/data_api/result/test_revision.py
@@ -1,0 +1,85 @@
+import copy
+import json
+
+from dl_api_lib_tests.db.base import DefaultApiTestBase
+
+
+class TestRevisionResult(DefaultApiTestBase):
+    def test_query_revision_result(self, saved_dataset, data_api, control_api, sync_us_manager):
+        ds = saved_dataset
+        usm = sync_us_manager
+        us_client = usm._us_client
+
+        entry_revisions = us_client.get_entry_revisions(ds.id)
+        assert len(entry_revisions) == 1
+        rev_id = entry_revisions[-1]["revId"]
+
+        result_resp = data_api.get_result(
+            dataset=ds,
+            fields=[
+                ds.find_field(title="discount"),
+                ds.find_field(title="city"),
+            ],
+            order_by=[
+                ds.find_field(title="discount").desc,
+            ],
+            query_params={
+                "rev_id": rev_id,
+            },
+        )
+        assert result_resp.status_code == 200
+
+    def test_prev_revision_result(self, saved_dataset, data_api, control_api, sync_us_manager):
+        ds = saved_dataset
+        usm = sync_us_manager
+        us_client = usm._us_client
+
+        entry_revisions = us_client.get_entry_revisions(ds.id)
+        assert len(entry_revisions) == 1
+        rev_id = entry_revisions[-1]["revId"]
+
+        dataset = control_api.client.get("/api/v1/datasets/{}/versions/draft".format(ds.id)).json
+        result_schema = copy.deepcopy(dataset["dataset"]["result_schema"])
+
+        new_result_schema = [item for item in result_schema if item["title"] != "city"]
+
+        resp = control_api.client.put(
+            "/api/v1/datasets/{}/versions/draft".format(saved_dataset.id),
+            data=json.dumps(
+                {
+                    "dataset": {
+                        "result_schema": new_result_schema,
+                    },
+                }
+            ),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+        result_resp = data_api.get_result(
+            dataset=ds,
+            fields=[
+                ds.find_field(title="discount"),
+                ds.find_field(title="city"),
+            ],
+            order_by=[
+                ds.find_field(title="discount").desc,
+            ],
+            fail_ok=True,
+        )
+        assert result_resp.status_code == 400
+
+        result_resp = data_api.get_result(
+            dataset=ds,
+            fields=[
+                ds.find_field(title="discount"),
+                ds.find_field(title="city"),
+            ],
+            order_by=[
+                ds.find_field(title="discount").desc,
+            ],
+            query_params={
+                "rev_id": rev_id,
+            },
+        )
+        assert result_resp.status_code == 200

--- a/lib/dl_api_lib_testing/dl_api_lib_testing/data_api_base.py
+++ b/lib/dl_api_lib_testing/dl_api_lib_testing/data_api_base.py
@@ -174,10 +174,12 @@ class StandardizedDataApiTestBase(DataApiTestBase, DatasetTestBase, metaclass=ab
         ds: Dataset,
         data_api: SyncHttpDataApiV2,
         field_names: Iterable[str],
+        query_params: dict | None = None,
     ) -> HttpDataApiResponse:
         data_resp = data_api.get_result(
             dataset=ds,
             fields=[ds.find_field(title=field_name) for field_name in field_names],
+            query_params=query_params,
         )
         assert data_resp.status_code == HTTPStatus.OK, data_resp.response_errors
         return data_resp


### PR DESCRIPTION
Unlike the [control-api](https://github.com/datalens-tech/datalens-backend/pull/865), the dataset revision_id substitution is not required here. It is expected that the revision_id of the dataset received by revId and the revision_id from the req_model match.