### PR TITLE
feat(datasets): BI-6229 support None revision_id in mutation cache

### DIFF
--- a/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/data_api/resources/dataset/base.py
@@ -389,7 +389,11 @@ class DatasetDataBaseView(BaseView):
     def try_get_mutation_key_for_dataset(
         dataset_id: Optional[str], revision_id: Optional[str], updates: List[Action]
     ) -> Optional[MutationKey]:
-        if dataset_id is not None and revision_id is not None:
+        # Cheat: replace None revision_id with empty string to allow caching
+        if revision_id is None:
+            revision_id = ""
+
+        if dataset_id is not None:
             if DatasetDataBaseView._updates_only_fields(updates):
                 return UpdateDatasetMutationKey.create(revision_id, updates)  # type: ignore  # 2024-01-30 # TODO: Argument 2 to "create" of "UpdateDatasetMutationKey" has incompatible type "list[Action]"; expected "list[FieldAction]"  [arg-type]
         return None
@@ -443,8 +447,12 @@ class DatasetDataBaseView(BaseView):
     ) -> Optional[Dataset]:
         if mutation_key is None or mutation_cache is None:
             return None
-        if dataset_id is None or revision_id is None:
+        if dataset_id is None:
             return None
+
+        # Cheat: replace None revision_id with empty string to allow caching
+        if revision_id is None:
+            revision_id = ""
 
         cached_dataset = await mutation_cache.get_mutated_entry_from_cache(
             Dataset,

--- a/lib/dl_core/dl_core/us_manager/mutation_cache/usentry_mutation_cache.py
+++ b/lib/dl_core/dl_core/us_manager/mutation_cache/usentry_mutation_cache.py
@@ -104,11 +104,16 @@ class USEntryMutationCache:
     async def save_mutation_cache(self, entry: USEntry, mutation_key: MutationKey) -> None:
         assert entry.uuid is not None
         assert entry.scope is not None
-        assert entry.revision_id is not None
+
+        # Cheat: replace None revision_id with empty string to allow caching
+        revision_id = entry.revision_id
+        if revision_id is None:
+            revision_id = ""
+
         key = USEntryMutationCacheKey(
             scope=entry.scope,
             entry_id=entry.uuid,
-            entry_revision_id=entry.revision_id,
+            entry_revision_id=revision_id,
             mutation_key_hash=mutation_key.get_hash(),
         )
         data = self._prepare_cache_data(entry, mutation_key)


### PR DESCRIPTION
When dataset is initially created/saved, it's revision_id is None. New revision_id is assigned only after first edit.
This patch adds workaround so revision_id=None mutations still can be cached in mutations cache. (Example case: create dataset and build chart with huge amount of computed fields)