### PR TITLE
feat: BI-6254 export-import feats and fixes

### DIFF
--- a/lib/dl_api_client/dl_api_client/dsmaker/api/dataset_api.py
+++ b/lib/dl_api_client/dl_api_client/dsmaker/api/dataset_api.py
@@ -225,16 +225,16 @@ class SyncHttpDatasetApiV1(SyncHttpApiV1Base):
             dataset=dataset,
         )
 
-    def export_dataset(self, dataset: Dataset, data: dict, bi_headers: dict) -> HttpDatasetApiResponse:
-        response = self._request(f"/api/v1/datasets/export/{dataset.id}", method="post", data=data, headers=bi_headers)
+    def export_dataset(self, dataset: Dataset, data: dict, headers: dict) -> HttpDatasetApiResponse:
+        response = self._request(f"/api/v1/datasets/export/{dataset.id}", method="post", data=data, headers=headers)
         return HttpDatasetApiResponse(
             json=response.json,
             status_code=response.status_code,
             dataset=None,
         )
 
-    def import_dataset(self, data: dict, bi_headers: dict) -> HttpDatasetApiResponse:
-        response = self._request("/api/v1/datasets/import", method="post", data=data, headers=bi_headers)
+    def import_dataset(self, data: dict, headers: dict) -> HttpDatasetApiResponse:
+        response = self._request("/api/v1/datasets/import", method="post", data=data, headers=headers)
         return HttpDatasetApiResponse(
             json=response.json,
             status_code=response.status_code,

--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
@@ -310,6 +310,7 @@ class DatasetExportItem(DatasetResource):
             ds_dict["dataset"]["name"] = dl_loc.entry_name
 
         ds_dict["dataset"]["revision_id"] = None
+        del ds_dict["dataset"]["rls"]
 
         notifications = []
         localizer = self.get_service_registry().get_localizer()

--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     ClassVar,
     Dict,
-    Sequence,
 )
 import uuid
 
@@ -19,7 +18,10 @@ from dl_api_lib import (
 )
 from dl_api_lib.api_decorators import schematic_request
 from dl_api_lib.app.control_api.resources import API
-from dl_api_lib.app.control_api.resources.base import BIResource
+from dl_api_lib.app.control_api.resources.base import (
+    BIResource,
+    wrap_export_import_exception,
+)
 from dl_api_lib.app.control_api.resources.dataset_base import DatasetResource
 from dl_api_lib.const import DEFAULT_DATASET_LOCK_WAIT_TIMEOUT
 from dl_api_lib.dataset.utils import (
@@ -28,19 +30,15 @@ from dl_api_lib.dataset.utils import (
     log_dataset_field_stats,
 )
 from dl_api_lib.enums import USPermissionKind
-from dl_api_lib.schemas import main as dl_api_main_schemas
 import dl_api_lib.schemas.data
 import dl_api_lib.schemas.dataset_base
+import dl_api_lib.schemas.main
 import dl_api_lib.schemas.validation
 from dl_constants.enums import (
     DataSourceCreatedVia,
     ManagedBy,
 )
-from dl_constants.exc import (
-    CODE_OK,
-    DEFAULT_ERR_CODE_API_PREFIX,
-    GLOBAL_ERR_PREFIX,
-)
+from dl_constants.exc import CODE_OK
 from dl_core.base_models import (
     EntryLocation,
     PathEntryLocation,
@@ -61,16 +59,6 @@ ns = API.namespace("Datasets", path="/datasets")
 VALIDATION_OK_MESSAGE = "Validation was successful"
 
 
-def _make_api_err_code(raw_code: Sequence[str]) -> str:
-    return ".".join(
-        (
-            GLOBAL_ERR_PREFIX,
-            DEFAULT_ERR_CODE_API_PREFIX,
-            *raw_code,
-        )
-    )
-
-
 @ns.route("/")
 class DatasetCollection(DatasetResource):
     @classmethod
@@ -85,9 +73,9 @@ class DatasetCollection(DatasetResource):
     @put_to_request_context(endpoint_code="DatasetCreate")
     @schematic_request(
         ns=ns,
-        body=dl_api_main_schemas.CreateDatasetSchema(),
+        body=dl_api_lib.schemas.main.CreateDatasetSchema(),
         responses={
-            200: ("Success", dl_api_main_schemas.CreateDatasetResponseSchema()),
+            200: ("Success", dl_api_lib.schemas.main.CreateDatasetResponseSchema()),
         },
     )
     def post(self, body: dict) -> dict:
@@ -300,6 +288,7 @@ class DatasetExportItem(DatasetResource):
             400: ("Failed", dl_api_lib.schemas.main.BadRequestResponseSchema()),
         },
     )
+    @wrap_export_import_exception
     def post(self, dataset_id: str, body: dict) -> dict:
         """Export dataset"""
 
@@ -310,7 +299,6 @@ class DatasetExportItem(DatasetResource):
 
         ds, _ = self.get_dataset(dataset_id=dataset_id, body={})
         ds_dict = ds.as_dict()
-        us_manager.load_dependencies(ds)
         ds_dict.update(
             self.make_dataset_response_data(
                 dataset=ds, us_entry_buffer=us_manager.get_entry_buffer(), conn_id_mapping=body["id_mapping"]
@@ -322,7 +310,6 @@ class DatasetExportItem(DatasetResource):
             ds_dict["dataset"]["name"] = dl_loc.entry_name
 
         ds_dict["dataset"]["revision_id"] = None
-        del ds_dict["dataset"]["rls"]
 
         notifications = []
         localizer = self.get_service_registry().get_localizer()
@@ -350,17 +337,32 @@ class DatasetImportCollection(DatasetResource):
 
     @classmethod
     def replace_conn_ids(cls, data: dict, conn_id_mapping: dict) -> None:
-        for sources in data["dataset"]["sources"]:
-            sources["connection_id"] = conn_id_mapping[sources["connection_id"]]
+        if "sources" not in data["dataset"]:
+            LOGGER.info("There are no sources in the passed dataset data, so nothing to replace")
+            return
+
+        for source in data["dataset"]["sources"]:
+            assert isinstance(source, dict)
+            fake_conn_id = source["connection_id"]
+            if fake_conn_id not in conn_id_mapping:
+                LOGGER.info(
+                    'Can not find "%s" in conn id mapping for source with id %s',
+                    fake_conn_id,
+                    source.get("id"),
+                )
+                raise exc.DatasetImportError("Can not import dataset without a connection")  # TODO BI-6296
+            else:
+                source["connection_id"] = conn_id_mapping[fake_conn_id]
 
     @put_to_request_context(endpoint_code="DatasetImport")
     @schematic_request(
         ns=ns,
-        body=dl_api_main_schemas.DatasetImportRequestSchema(),
+        body=dl_api_lib.schemas.main.DatasetImportRequestSchema(),
         responses={
-            200: ("Success", dl_api_main_schemas.ImportResponseSchema()),
+            200: ("Success", dl_api_lib.schemas.main.ImportResponseSchema()),
         },
     )
+    @wrap_export_import_exception
     def post(self, body: dict) -> dict:
         """Import dataset"""
 
@@ -438,7 +440,7 @@ class DatasetVersionValidator(DatasetResource):
             ds_validator.apply_batch(action_batch=body.get("updates", ()))
         except exc.DLValidationFatal as err:
             any_errors = True
-            code = _make_api_err_code(exc.DLValidationFatal.err_code)
+            code = self._make_api_err_code(exc.DLValidationFatal.err_code)
             message = err.message
         else:
             # collect connections not found in us
@@ -447,7 +449,7 @@ class DatasetVersionValidator(DatasetResource):
 
             # check for errors
             any_errors = bool(dataset.error_registry.items)
-            code = _make_api_err_code(exc.DLValidationError.err_code) if any_errors else CODE_OK
+            code = self._make_api_err_code(exc.DLValidationError.err_code) if any_errors else CODE_OK
             message = exc.DLValidationError.default_message if any_errors else VALIDATION_OK_MESSAGE
             data.update(self.make_dataset_response_data(dataset=dataset, us_entry_buffer=us_manager.get_entry_buffer()))
 
@@ -493,7 +495,7 @@ class DatasetVersionFieldValidator(DatasetResource):
         formula = body["field"]["formula"]
         # TODO full validation (with aggregation check for this field), not just formula
         field_errors = ds_validator.get_single_formula_errors(formula)
-        code = _make_api_err_code(exc.DLValidationError.err_code) if field_errors else CODE_OK
+        code = self._make_api_err_code(exc.DLValidationError.err_code) if field_errors else CODE_OK
         message = exc.DLValidationError.default_message if field_errors else VALIDATION_OK_MESSAGE
         error_data = {
             "field_errors": [

--- a/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset_base.py
+++ b/lib/dl_api_lib/dl_api_lib/app/control_api/resources/dataset_base.py
@@ -212,7 +212,7 @@ class DatasetResource(BIResource):
         for item in data["component_errors"].items:
             for error in item.errors:
                 if error.code[:2] != [GLOBAL_ERR_PREFIX, DEFAULT_ERR_CODE_API_PREFIX]:
-                    error.code = cls._make_api_err_code(error.code)
+                    error.code = [GLOBAL_ERR_PREFIX, DEFAULT_ERR_CODE_API_PREFIX] + error.code
 
         data["created_via"] = dataset.created_via
 

--- a/lib/dl_api_lib/dl_api_lib/error_handling.py
+++ b/lib/dl_api_lib/dl_api_lib/error_handling.py
@@ -94,7 +94,8 @@ EXCEPTION_CODES = {
     common_exc.UnknownEntryMigration: status.NOT_IMPLEMENTED,
     common_exc.FailedToLoadSchema: status.BAD_REQUEST,
     common_exc.InvalidRequestError: status.BAD_REQUEST,
-    exc.DatasetExportError: status.BAD_REQUEST,
+    exc.WorkbookImportError: status.BAD_REQUEST,
+    exc.WorkbookExportError: status.BAD_REQUEST,
 }
 
 

--- a/lib/dl_api_lib/dl_api_lib/exc.py
+++ b/lib/dl_api_lib/dl_api_lib/exc.py
@@ -31,14 +31,29 @@ class WorkbookExportError(DLBaseException):
     default_message = "Error while performing workbook export."
 
 
-class DatasetExportError(DLBaseException):
+class DatasetExportError(WorkbookExportError):
     err_code = WorkbookExportError.err_code + ["DS"]
     default_message = "Error while performing dataset export."
 
 
-class ConnectionExportError(DLBaseException):
+class ConnectionExportError(WorkbookExportError):
     err_code = WorkbookExportError.err_code + ["CONN"]
     default_message = "Error while performing connection export."
+
+
+class WorkbookImportError(DLBaseException):
+    err_code = DLBaseException.err_code + ["WB_IMPORT"]
+    default_message = "Error while performing workbook import."
+
+
+class DatasetImportError(WorkbookImportError):
+    err_code = WorkbookImportError.err_code + ["DS"]
+    default_message = "Error while performing dataset import."
+
+
+class ConnectionImportError(WorkbookImportError):
+    err_code = WorkbookImportError.err_code + ["CONN"]
+    default_message = "Error while performing connection import."
 
 
 class _DLValidationResult(DLBaseException):

--- a/lib/dl_api_lib/dl_api_lib/schemas/main.py
+++ b/lib/dl_api_lib/dl_api_lib/schemas/main.py
@@ -185,9 +185,6 @@ class NotificationContentSchema(BaseSchema):
 
 class DatasetExportResponseSchema(BaseSchema):
     class DatasetContentInternalExportSchema(DatasetContentInternalSchema):
-        class Meta(DatasetContentInternalSchema.Meta):
-            exclude = ("rls",)  # not exporting rls at all, only rls2
-
         name = ma_fields.String()
 
     dataset = ma_fields.Nested(DatasetContentInternalExportSchema)

--- a/lib/dl_api_lib/dl_api_lib/schemas/main.py
+++ b/lib/dl_api_lib/dl_api_lib/schemas/main.py
@@ -185,6 +185,9 @@ class NotificationContentSchema(BaseSchema):
 
 class DatasetExportResponseSchema(BaseSchema):
     class DatasetContentInternalExportSchema(DatasetContentInternalSchema):
+        class Meta(DatasetContentInternalSchema.Meta):
+            exclude = ("rls",)  # not exporting rls at all, only rls2
+
         name = ma_fields.String()
 
     dataset = ma_fields.Nested(DatasetContentInternalExportSchema)
@@ -208,4 +211,4 @@ class DatasetImportRequestSchema(IdMappingContentSchema):
 
 class ImportResponseSchema(BaseSchema):
     notifications = ma_fields.Nested(NotificationContentSchema, many=True)
-    id = ma_fields.String(required=True)
+    id = ma_fields.String()

--- a/lib/dl_api_lib_testing/dl_api_lib_testing/connector/connection_suite.py
+++ b/lib/dl_api_lib_testing/dl_api_lib_testing/connector/connection_suite.py
@@ -9,6 +9,7 @@ from dl_api_lib.app_settings import ControlApiAppSettings
 from dl_api_lib.schemas.connection import GenericConnectionSchema
 from dl_api_lib_testing.connection_base import ConnectionTestBase
 from dl_constants.api_constants import DLHeadersCommon
+from dl_core.connectors.base.export_import import is_export_import_allowed
 from dl_core.us_connection_base import ConnectionBase
 from dl_core.us_manager.us_manager_sync import SyncUSManager
 from dl_testing.regulated_test import RegulatedTestCase
@@ -52,7 +53,7 @@ class DefaultConnectorConnectionTestSuite(ConnectionTestBase, RegulatedTestCase)
             headers=bi_headers,
         )
 
-        if not conn.allow_export:
+        if not is_export_import_allowed(self.conn_type):
             assert resp.status_code == 200, resp.json
             assert "notifications" in resp.json, resp.json
             assert resp.json["notifications"][0]["code"] == "ERR.DS_API.UNSUPPORTED", resp.json
@@ -75,7 +76,7 @@ class DefaultConnectorConnectionTestSuite(ConnectionTestBase, RegulatedTestCase)
     ) -> None:
         conn = sync_us_manager.get_by_id(saved_connection_id, expected_type=ConnectionBase)
         assert isinstance(conn, ConnectionBase)
-        if not conn.allow_export:
+        if not is_export_import_allowed(self.conn_type):
             return
 
         us_master_token = control_api_app_settings.US_MASTER_TOKEN

--- a/lib/dl_api_lib_testing/dl_api_lib_testing/connector/connection_suite.py
+++ b/lib/dl_api_lib_testing/dl_api_lib_testing/connector/connection_suite.py
@@ -53,7 +53,9 @@ class DefaultConnectorConnectionTestSuite(ConnectionTestBase, RegulatedTestCase)
         )
 
         if not conn.allow_export:
-            assert resp.status_code == 400
+            assert resp.status_code == 200, resp.json
+            assert "notifications" in resp.json, resp.json
+            assert resp.json["notifications"][0]["code"] == "ERR.DS_API.UNSUPPORTED", resp.json
             return
 
         assert resp.status_code == 200, resp.json

--- a/lib/dl_api_lib_testing/dl_api_lib_testing/connector/dataset_suite.py
+++ b/lib/dl_api_lib_testing/dl_api_lib_testing/connector/dataset_suite.py
@@ -92,6 +92,7 @@ class DefaultConnectorDatasetTestSuite(DatasetTestBase, RegulatedTestCase, metac
 
     @pytest.fixture(scope="function")
     def export_import_headers(self, control_api_app_settings: ControlApiAppSettings) -> dict[str, str]:
+        assert control_api_app_settings.US_MASTER_TOKEN is not None
         return {
             DLHeadersCommon.US_MASTER_TOKEN.value: control_api_app_settings.US_MASTER_TOKEN,
         }
@@ -101,12 +102,12 @@ class DefaultConnectorDatasetTestSuite(DatasetTestBase, RegulatedTestCase, metac
         control_api: SyncHttpDatasetApiV1,
         saved_dataset: Dataset,
         export_import_headers: dict[str, str],
-    ):
-        export_data = dict()
+    ) -> None:
+        export_data: dict = dict()
         export_resp = control_api.export_dataset(dataset=saved_dataset, data=export_data, headers=export_import_headers)
         assert export_resp.status_code == 400, export_resp.json
 
-        import_data = dict()
+        import_data: dict = dict()
         import_resp = control_api.import_dataset(data=import_data, headers=export_import_headers)
         assert import_resp.status_code == 400, import_resp.json
 
@@ -144,11 +145,11 @@ class DefaultConnectorDatasetTestSuite(DatasetTestBase, RegulatedTestCase, metac
         sync_us_manager: SyncUSManager,
         saved_dataset: Dataset,
         export_import_headers: dict[str, str],
-    ):
+    ) -> None:
         sync_us_manager.delete(sync_us_manager.get_by_id(saved_connection_id))
 
         # export with no connection
-        export_req_data = {"id_mapping": {}}
+        export_req_data: dict = {"id_mapping": {}}
         export_resp = control_api.export_dataset(
             dataset=saved_dataset, data=export_req_data, headers=export_import_headers
         )

--- a/lib/dl_connector_bigquery/dl_connector_bigquery/core/connector.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery/core/connector.py
@@ -40,6 +40,7 @@ class BigQueryCoreConnectionDefinition(CoreConnectionDefinition):
     sync_conn_executor_cls = BigQueryAsyncConnExecutor
     async_conn_executor_cls = BigQueryAsyncConnExecutor
     dialect_string = "bigquery"
+    allow_export = True
 
 
 class BigQueryCoreTableSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_bigquery/dl_connector_bigquery/core/us_connection.py
+++ b/lib/dl_connector_bigquery/dl_connector_bigquery/core/us_connection.py
@@ -39,7 +39,6 @@ class ConnectionSQLBigQuery(ConnectionSQL):
     allowed_source_types = frozenset((SOURCE_TYPE_BIGQUERY_TABLE, SOURCE_TYPE_BIGQUERY_SUBSELECT))
     allow_dashsql: ClassVar[bool] = False
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
 
     @attr.s

--- a/lib/dl_connector_bitrix_gds/dl_connector_bitrix_gds/core/connector.py
+++ b/lib/dl_connector_bitrix_gds/dl_connector_bitrix_gds/core/connector.py
@@ -28,6 +28,7 @@ class BitrixGDSCoreConnectionDefinition(CoreConnectionDefinition):
     sync_conn_executor_cls = BitrixGDSAsyncAdapterConnExecutor
     async_conn_executor_cls = BitrixGDSAsyncAdapterConnExecutor
     dialect_string = "bi_bitrix"
+    allow_export = True
 
 
 class BitrixGDSCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_bitrix_gds/dl_connector_bitrix_gds/core/us_connection.py
+++ b/lib/dl_connector_bitrix_gds/dl_connector_bitrix_gds/core/us_connection.py
@@ -34,7 +34,6 @@ class BitrixGDSConnectOptions(ConnectOptions):
 
 class BitrixGDSConnection(ConnectionBase):
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     source_type = SOURCE_TYPE_BITRIX_GDS
 
     @attr.s(kw_only=True)

--- a/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_base/core/us_connection.py
+++ b/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_base/core/us_connection.py
@@ -53,7 +53,6 @@ class BaseFileS3Connection(
 ):
     is_always_internal_source: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     settings_type = FileS3ConnectorSettings
 
     editable_data_source_parameters: ClassVar[tuple[str, ...]] = (

--- a/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_gsheets/core/connector.py
+++ b/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_gsheets/core/connector.py
@@ -37,6 +37,7 @@ class GSheetsFileS3CoreConnectionDefinition(BaseFileS3CoreConnectionDefinition):
     lifecycle_manager_cls = GSheetsFileS3ConnectionLifecycleManager
     dialect_string = "bi_clickhouse"
     settings_definition = GSheetsFileS3SettingDefinition
+    allow_export = True
 
 
 class GSheetsFileS3TableCoreSourceDefinition(BaseFileS3TableCoreSourceDefinition):

--- a/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_yadocs/core/connector.py
+++ b/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/chs3_yadocs/core/connector.py
@@ -37,6 +37,7 @@ class YaDocsFileS3CoreConnectionDefinition(BaseFileS3CoreConnectionDefinition):
     lifecycle_manager_cls = YaDocsFileS3ConnectionLifecycleManager
     dialect_string = "bi_clickhouse"
     settings_definition = YaDocsFileS3SettingDefinition
+    allow_export = True
 
 
 class YaDocsFileS3TableCoreSourceDefinition(BaseFileS3TableCoreSourceDefinition):

--- a/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/file/core/connector.py
+++ b/lib/dl_connector_bundle_chs3/dl_connector_bundle_chs3/file/core/connector.py
@@ -31,6 +31,7 @@ class FileS3CoreConnectionDefinition(BaseFileS3CoreConnectionDefinition):
     lifecycle_manager_cls = FileS3ConnectionLifecycleManager
     dialect_string = "bi_clickhouse"
     settings_definition = FileS3SettingDefinition
+    allow_export = True
 
 
 class FileS3TableCoreSourceDefinition(BaseFileS3TableCoreSourceDefinition):

--- a/lib/dl_connector_chyt/dl_connector_chyt/core/connector.py
+++ b/lib/dl_connector_chyt/dl_connector_chyt/core/connector.py
@@ -57,6 +57,7 @@ class CHYTCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_chyt"
     settings_definition = CHYTSettingDefinition
     data_source_migrator_cls = CHYTDataSourceMigrator
+    allow_export = True
 
 
 class CHYTTableCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_chyt/dl_connector_chyt/core/us_connection.py
+++ b/lib/dl_connector_chyt/dl_connector_chyt/core/us_connection.py
@@ -183,7 +183,6 @@ class BaseConnectionCHYT(
 
 class ConnectionCHYTToken(BaseConnectionCHYT):
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
 
     source_type = SOURCE_TYPE_CHYT_YTSAURUS_TABLE
     allowed_source_types = frozenset(

--- a/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse/connector.py
+++ b/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse/connector.py
@@ -41,6 +41,7 @@ class ClickHouseCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_clickhouse"
     data_source_migrator_cls = ClickHouseDataSourceMigrator
     settings_definition = ClickHouseSettingDefinition
+    allow_export = True
 
 
 class ClickHouseTableCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse/us_connection.py
+++ b/lib/dl_connector_clickhouse/dl_connector_clickhouse/core/clickhouse/us_connection.py
@@ -42,7 +42,6 @@ class ConnectionClickhouse(
 
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = False  # TODO: should be `True`, but need some cleanup for that.
 
     def get_data_source_template_templates(self, localizer: Localizer) -> list[DataSourceTemplate]:

--- a/lib/dl_connector_greenplum/dl_connector_greenplum/core/connector.py
+++ b/lib/dl_connector_greenplum/dl_connector_greenplum/core/connector.py
@@ -45,6 +45,7 @@ class GreenplumCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_postgresql"
     data_source_migrator_cls = GreenPlumDataSourceMigrator
     settings_definition = GreenplumSettingDefinition
+    allow_export = True
 
 
 class GreenplumTableCoreSourceDefinition(SQLTableCoreSourceDefinitionBase):

--- a/lib/dl_connector_greenplum/dl_connector_greenplum/core/us_connection.py
+++ b/lib/dl_connector_greenplum/dl_connector_greenplum/core/us_connection.py
@@ -27,7 +27,6 @@ class GreenplumConnection(
     allowed_source_types = frozenset((SOURCE_TYPE_GP_TABLE, SOURCE_TYPE_GP_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     settings_type = GreenplumConnectorSettings
 

--- a/lib/dl_connector_metrica/dl_connector_metrica/core/connector.py
+++ b/lib/dl_connector_metrica/dl_connector_metrica/core/connector.py
@@ -68,6 +68,7 @@ class MetricaApiCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "metrika_api"
     settings_definition = MetricaSettingDefinition
     data_source_migrator_cls = MetricaApiDataSourceMigrator
+    allow_export = False
 
 
 class MetricaApiCoreSourceDefinition(CoreSourceDefinition):
@@ -104,6 +105,7 @@ class AppMetricaApiCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "appmetrica_api"
     settings_definition = AppMetricaSettingDefinition
     data_source_migrator_cls = AppMetricaApiDataSourceMigrator
+    allow_export = False
 
 
 class AppMetricaApiCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_mssql/dl_connector_mssql/core/connector.py
+++ b/lib/dl_connector_mssql/dl_connector_mssql/core/connector.py
@@ -41,6 +41,7 @@ class MSSQLCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_mssql"
     data_source_migrator_cls = MSSQLDataSourceMigrator
     settings_definition = MSSQLSettingDefinition
+    allow_export = True
 
 
 class MSSQLTableCoreSourceDefinition(SQLTableCoreSourceDefinitionBase):

--- a/lib/dl_connector_mssql/dl_connector_mssql/core/us_connection.py
+++ b/lib/dl_connector_mssql/dl_connector_mssql/core/us_connection.py
@@ -36,7 +36,6 @@ class ConnectionMSSQL(
     allowed_source_types = frozenset((SOURCE_TYPE_MSSQL_TABLE, SOURCE_TYPE_MSSQL_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     settings_type = MSSQLConnectorSettings
 

--- a/lib/dl_connector_mysql/dl_connector_mysql/core/connector.py
+++ b/lib/dl_connector_mysql/dl_connector_mysql/core/connector.py
@@ -43,6 +43,7 @@ class MySQLCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "dl_mysql"
     data_source_migrator_cls = MySQLDataSourceMigrator
     settings_definition = MySQLSettingDefinition
+    allow_export = True
 
 
 class MySQLTableCoreSourceDefinition(SQLTableCoreSourceDefinitionBase):

--- a/lib/dl_connector_mysql/dl_connector_mysql/core/us_connection.py
+++ b/lib/dl_connector_mysql/dl_connector_mysql/core/us_connection.py
@@ -32,7 +32,6 @@ class ConnectionMySQL(
     allowed_source_types = frozenset((SOURCE_TYPE_MYSQL_TABLE, SOURCE_TYPE_MYSQL_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     settings_type = MySQLConnectorSettings
 

--- a/lib/dl_connector_oracle/dl_connector_oracle/core/connector.py
+++ b/lib/dl_connector_oracle/dl_connector_oracle/core/connector.py
@@ -40,6 +40,7 @@ class OracleCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_oracle"
     data_source_migrator_cls = OracleDataSourceMigrator
     settings_definition = OracleSettingDefinition
+    allow_export = True
 
 
 class OracleTableCoreSourceDefinition(SQLTableCoreSourceDefinitionBase):

--- a/lib/dl_connector_oracle/dl_connector_oracle/core/us_connection.py
+++ b/lib/dl_connector_oracle/dl_connector_oracle/core/us_connection.py
@@ -40,7 +40,6 @@ class ConnectionSQLOracle(
     allowed_source_types = frozenset((SOURCE_TYPE_ORACLE_TABLE, SOURCE_TYPE_ORACLE_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     settings_type = OracleConnectorSettings
 

--- a/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql/connector.py
+++ b/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql/connector.py
@@ -43,6 +43,7 @@ class PostgreSQLCoreConnectionDefinition(CoreConnectionDefinition):
     dialect_string = "bi_postgresql"
     data_source_migrator_cls = PostgreSQLDataSourceMigrator
     settings_definition = PostgreSQLSettingDefinition
+    allow_export = True
 
 
 class PostgreSQLTableCoreSourceDefinition(SQLTableCoreSourceDefinitionBase):

--- a/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql/us_connection.py
+++ b/lib/dl_connector_postgresql/dl_connector_postgresql/core/postgresql/us_connection.py
@@ -27,7 +27,6 @@ class ConnectionPostgreSQL(
     allowed_source_types = frozenset((SOURCE_TYPE_PG_TABLE, SOURCE_TYPE_PG_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     settings_type = PostgreSQLConnectorSettings
 

--- a/lib/dl_connector_promql/dl_connector_promql/core/connector.py
+++ b/lib/dl_connector_promql/dl_connector_promql/core/connector.py
@@ -33,6 +33,7 @@ class PromQLCoreConnectionDefinition(CoreConnectionDefinition):
     async_conn_executor_cls = PromQLAsyncAdapterConnExecutor
     dialect_string = "bi_promql"
     custom_dashsql_key_names = frozenset(("from", "to", "step"))
+    allow_export = True
 
 
 class PromQLCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_promql/dl_connector_promql/core/us_connection.py
+++ b/lib/dl_connector_promql/dl_connector_promql/core/us_connection.py
@@ -17,7 +17,6 @@ class PromQLConnection(ClassicConnectionSQL):
     allow_cache: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     allow_dashsql: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     source_type = SOURCE_TYPE_PROMQL
 
     @attr.s(kw_only=True)

--- a/lib/dl_connector_snowflake/dl_connector_snowflake/core/connector.py
+++ b/lib/dl_connector_snowflake/dl_connector_snowflake/core/connector.py
@@ -40,6 +40,7 @@ class SnowFlakeCoreConnectionDefinition(CoreConnectionDefinition):
     sync_conn_executor_cls = SnowFlakeSyncConnExecutor
     lifecycle_manager_cls = SnowFlakeConnectionLifecycleManager
     dialect_string = "snowflake"
+    allow_export = True
 
 
 class SnowFlakeCoreTableSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_trino/dl_connector_trino/core/connector.py
+++ b/lib/dl_connector_trino/dl_connector_trino/core/connector.py
@@ -38,6 +38,7 @@ class TrinoCoreConnectionDefinition(CoreConnectionDefinition):
     # lifecycle_manager_cls = TrinoConnectionLifecycleManager
     data_source_migrator_cls = TrinoDataSourceMigrator
     dialect_string = "trino"
+    allow_export = True
 
 
 class TrinoCoreTableSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_trino/dl_connector_trino/core/us_connection.py
+++ b/lib/dl_connector_trino/dl_connector_trino/core/us_connection.py
@@ -60,7 +60,6 @@ class ConnectionTrino(ConnectionSQL):
     allowed_source_types = frozenset((SOURCE_TYPE_TRINO_TABLE, SOURCE_TYPE_TRINO_SUBSELECT))
     allow_dashsql: ClassVar[bool] = True
     allow_cache: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
 
     @attr.s(kw_only=True)

--- a/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/connector.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/connector.py
@@ -43,6 +43,7 @@ class YDBCoreConnectionDefinition(CoreConnectionDefinition):
     async_conn_executor_cls = YDBAsyncAdapterConnExecutor
     dialect_string = "yql"
     settings_definition = YDBSettingDefinition
+    allow_export = True
 
 
 class YDBCoreSourceDefinition(CoreSourceDefinition):

--- a/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/us_connection.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb/core/ydb/us_connection.py
@@ -43,7 +43,6 @@ class YDBConnection(
     allow_cache: ClassVar[bool] = True
     is_always_user_source: ClassVar[bool] = True
     allow_dashsql: ClassVar[bool] = True
-    allow_export: ClassVar[bool] = True
     settings_type = YDBConnectorSettings
 
     source_type = SOURCE_TYPE_YDB_TABLE

--- a/lib/dl_connector_ydb/dl_connector_ydb_tests/db/api/test_connection.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb_tests/db/api/test_connection.py
@@ -4,6 +4,7 @@ from dl_api_client.dsmaker.api.http_sync_base import SyncHttpClientBase
 from dl_api_lib.app_settings import ControlApiAppSettings
 from dl_api_lib_testing.connector.connection_suite import DefaultConnectorConnectionTestSuite
 from dl_constants.api_constants import DLHeadersCommon
+from dl_core.connectors.base.export_import import is_export_import_allowed
 from dl_core.us_connection_base import ConnectionBase
 from dl_core.us_manager.us_manager_sync import SyncUSManager
 
@@ -36,7 +37,7 @@ class TestYDBConnection(YDBConnectionTestBase, DefaultConnectorConnectionTestSui
             headers=bi_headers,
         )
 
-        if not conn.allow_export:
+        if not is_export_import_allowed(self.conn_type):
             assert resp.status_code == 400
             return
 

--- a/lib/dl_core/dl_core/connectors/base/connector.py
+++ b/lib/dl_core/dl_core/connectors/base/connector.py
@@ -74,6 +74,7 @@ class CoreConnectionDefinition(abc.ABC):
     data_source_migrator_cls: ClassVar[Type[DataSourceMigrator]] = DefaultDataSourceMigrator
     settings_definition: ClassVar[Optional[Type[ConnectorSettingsDefinition]]] = None
     custom_dashsql_key_names: frozenset[str] = frozenset()
+    allow_export: ClassVar[bool] = False
 
 
 class CoreBackendDefinition(abc.ABC):

--- a/lib/dl_core/dl_core/connectors/base/export_import.py
+++ b/lib/dl_core/dl_core/connectors/base/export_import.py
@@ -1,0 +1,12 @@
+from dl_constants.enums import ConnectionType
+
+
+_EXPORT_IMPORT_ALLOWED_BY_CONN_TYPE: dict[ConnectionType, bool] = {}
+
+
+def register_export_import_allowed(conn_type: ConnectionType, value: bool) -> None:
+    _EXPORT_IMPORT_ALLOWED_BY_CONN_TYPE[conn_type] = value
+
+
+def is_export_import_allowed(conn_type: ConnectionType) -> bool:
+    return _EXPORT_IMPORT_ALLOWED_BY_CONN_TYPE[conn_type]

--- a/lib/dl_core/dl_core/connectors/base/registrator.py
+++ b/lib/dl_core/dl_core/connectors/base/registrator.py
@@ -15,6 +15,7 @@ from dl_core.connectors.base.connector import (
 )
 from dl_core.connectors.base.dashsql import register_custom_dash_sql_key_names
 from dl_core.connectors.base.data_source_migration import register_data_source_migrator
+from dl_core.connectors.base.export_import import register_export_import_allowed
 from dl_core.connectors.settings.registry import register_connector_settings_class
 from dl_core.data_processing.query_compiler_registry import register_sa_query_compiler_cls
 from dl_core.data_source.type_mapping import register_data_source_class
@@ -89,6 +90,7 @@ class CoreConnectorRegistrator:
             )
         register_data_source_migrator(conn_type=conn_def.conn_type, migrator_cls=conn_def.data_source_migrator_cls)
         register_custom_dash_sql_key_names(conn_type=conn_def.conn_type, key_names=conn_def.custom_dashsql_key_names)
+        register_export_import_allowed(conn_type=conn_def.conn_type, value=conn_def.allow_export)
 
     @classmethod
     def register_backend_definition(cls, backend_def: Type[CoreBackendDefinition]) -> None:

--- a/lib/dl_core/dl_core/us_connection_base.py
+++ b/lib/dl_core/dl_core/us_connection_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import functools
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -456,7 +457,13 @@ class ConnectionBase(USEntry, metaclass=abc.ABCMeta):
     def get_import_warnings_list(self, localizer: Localizer) -> list[dict]:
         CODE_PREFIX = "NOTIF.WB_IMPORT.CONN."
         warnings = []
-        if self.data.get_secret_keys():
+        with_fake_creds = False
+        for data_key in self.data.get_secret_keys():
+            secret_value = functools.reduce(getattr, data_key.parts, self.data)
+            if secret_value == "******":
+                with_fake_creds = True
+                break
+        if with_fake_creds:
             warnings.append(
                 dict(
                     message=localizer.translate(Translatable("notif_check-creds")),


### PR DESCRIPTION
- wrap all uncaught export-import related exceptions into [200 OK + notifications]
- check if export is allowed for a connection type before trying to load it – move allow_export flag into CoreConnectionDefinition
- send CHECK_CREDENTIALS notification on import only when secret values are fake to reduce noise a bit
- update tests accordingly