### PR TITLE
feat(connectors): BI-6326 expand the list of allowed yadocs domains

### DIFF
--- a/lib/dl_file_uploader_api_lib/dl_file_uploader_api_lib/data_file_preparer.py
+++ b/lib/dl_file_uploader_api_lib/dl_file_uploader_api_lib/data_file_preparer.py
@@ -85,9 +85,11 @@ async def yadocs_data_file_preparer(
         if parts.scheme not in ("http", "https"):
             raise InvalidLink(f"Invalid url scheme: {parts.scheme!r}, must be 'http' or 'https'; {example_url_message}")
         host = parts.hostname
-        if not YADOCS_HOST_PATTERN.match(host):
+        if host is None or not YADOCS_HOST_PATTERN.match(host):
             raise InvalidLink(
-                f'Invalid host: {host!r}; should match the following regular expression: "{YADOCS_HOST_PATTERN_STR}"; {example_url_message}'
+                f"Invalid host: {host!r}; "
+                f'should match the following regular expression: "{YADOCS_HOST_PATTERN_STR}"; '
+                f"{example_url_message}"
             )
 
         path = parts.path

--- a/lib/dl_file_uploader_api_lib/dl_file_uploader_api_lib/data_file_preparer.py
+++ b/lib/dl_file_uploader_api_lib/dl_file_uploader_api_lib/data_file_preparer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Optional
 import urllib.parse
 
@@ -17,6 +18,11 @@ from dl_file_uploader_lib.redis_model.models.models import (
 
 
 LOGGER = logging.getLogger(__name__)
+
+YADOCS_HOST_PATTERN_STR = (
+    r"^disk(\.360)?\.yandex\.(ru|az|by|co\.il|com|com\.am|com\.ge|com\.tr|ee|fr|kg|kz|lt|lv|md|tj|tm|uz)$"
+)
+YADOCS_HOST_PATTERN = re.compile(YADOCS_HOST_PATTERN_STR)
 
 
 async def gsheets_data_file_preparer(
@@ -72,8 +78,6 @@ async def yadocs_data_file_preparer(
     public_link: Optional[str],
     redis_model_manager: RedisModelManager,
 ) -> DataFile:
-    default_host: str = "disk.yandex.ru"
-    allowed_hosts: frozenset[str] = frozenset({default_host})
     example_url: str = "https://disk.yandex.ru/i/OyzdmFI0MUEEgA"
     example_url_message: str = f"example: {example_url!r}"
     if public_link is not None:
@@ -81,8 +85,10 @@ async def yadocs_data_file_preparer(
         if parts.scheme not in ("http", "https"):
             raise InvalidLink(f"Invalid url scheme: {parts.scheme!r}, must be 'http' or 'https'; {example_url_message}")
         host = parts.hostname
-        if host not in allowed_hosts:
-            raise InvalidLink(f"Invalid host: {host!r}; should be {default_host!r}; {example_url_message}")
+        if not YADOCS_HOST_PATTERN.match(host):
+            raise InvalidLink(
+                f'Invalid host: {host!r}; should match the following regular expression: "{YADOCS_HOST_PATTERN_STR}"; {example_url_message}'
+            )
 
         path = parts.path
         prefix = "/i/"


### PR DESCRIPTION
Full list of allowed domains

These were always there:
- `disk.yandex.ru`
- `disk.yandex.az`
- `disk.yandex.by`
- `disk.yandex.co.il`
- `disk.yandex.com`
- `disk.yandex.com.am`
- `disk.yandex.com.ge`
- `disk.yandex.com.tr`
- `disk.yandex.ee`
- `disk.yandex.fr`
- `disk.yandex.kg`
- `disk.yandex.kz`
- `disk.yandex.lt`
- `disk.yandex.lv`
- `disk.yandex.md`
- `disk.yandex.tj`
- `disk.yandex.tm`
- `disk.yandex.uz`

These were added recently:
- `disk.360.yandex.ru`
- `disk.360.yandex.az`
- `disk.360.yandex.by`
- `disk.360.yandex.co.il`
- `disk.360.yandex.com`
- `disk.360.yandex.com.am`
- `disk.360.yandex.com.ge`
- `disk.360.yandex.com.tr`
- `disk.360.yandex.ee`
- `disk.360.yandex.fr`
- `disk.360.yandex.kg`
- `disk.360.yandex.kz`
- `disk.360.yandex.lt`
- `disk.360.yandex.lv`
- `disk.360.yandex.md`
- `disk.360.yandex.tj`
- `disk.360.yandex.tm`
- `disk.360.yandex.uz`
