### PR TITLE
dev: BI-6548 remove unused build arguments

### DIFF
--- a/lib/dl_connector_mysql/docker-compose/rogue_mysql_server/Taskfile.yaml
+++ b/lib/dl_connector_mysql/docker-compose/rogue_mysql_server/Taskfile.yaml
@@ -23,8 +23,6 @@ tasks:
     cmds:
       - docker buildx build
         --build-context sources="{{.ROGUE_MYSQL_SERVER_SOURCE}}"
-        --build-arg REPO_OWNER="{{.REPO_OWNER}}"
-        --build-arg REPO_NAME="{{.REPO_NAME}}"
         --tag "ghcr.io/{{.REPO_OWNER}}/{{.REPO_NAME}}/{{.IMG_REPO}}:{{.IMG_TAG}}"
         --platform "{{.TARGET_PLATFORM}}"
         --annotation="org.opencontainers.image.source=https://github.com/{{.REPO_OWNER}}/{{.REPO_NAME}}"


### PR DESCRIPTION
Forgot to remove these now unused arguments from when I was struggling with github package annotations