### PR TITLE
test: BI-5971 Test for YDB interval to integer precision

### DIFF
--- a/lib/dl_connector_ydb/dl_connector_ydb_tests/db/api/test_dashsql.py
+++ b/lib/dl_connector_ydb/dl_connector_ydb_tests/db/api/test_dashsql.py
@@ -112,7 +112,7 @@ class TestYDBDashSQL(YDBDashSQLConnectionTest, DefaultDashSQLTestSuite):
         ]
 
         assert resp_data[1]["event"] == "row", resp_data
-        assert resp_data[1]["data"] == [ 1_000_000 ]
+        assert resp_data[1]["data"] == [1_000_000]
 
     @pytest.mark.asyncio
     async def test_result_with_error(self, data_api_lowlevel_aiohttp_client: TestClient, saved_connection_id: str):


### PR DESCRIPTION
Currently YDB cast to DL Integer transforms Interval into microseconds precision