### PR TITLE
ci: BI-7421 trigger main.yml on push to main only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,13 @@
 name: "🔄 Main"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
 
 on:
-  # Subject to change back to pull_request when we have a better solution for the CI with forked PRs
-  pull_request_target: # zizmor: ignore[dangerous-triggers]
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
-      - unlabeled
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       run_for_all_packages:
@@ -25,99 +20,8 @@ on:
         description: "Skip tests"
 
 jobs:
-  drop-ci-approved-label:
-    name: Drop CI Allowed label if PR branch changed
-    runs-on: ubuntu-22.04
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Drop label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY_FULL_NAME: ${{ github.event.repository.full_name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-        run: |
-          [[ $EVENT_NAME != "pull_request_target" ]] && exit 0
-
-          action=$EVENT_ACTION
-          [[ $action == "labeled" || $action == "unlabeled" || $action == "opened" ]] && exit 0
-
-          gh pr edit \
-            --repo $REPOSITORY_FULL_NAME \
-            --remove-label "ci-approved" \
-            $PULL_REQUEST_NUMBER
-
-
-  check-ci-allowed:
-    name: Check if CI allowed for PR
-    runs-on: ubuntu-22.04
-
-    needs: [ drop-ci-approved-label ]
-
-    permissions:
-      contents: read
-      pull-requests: read
-
-    env:
-      GH_TOKEN: ${{ github.token }}
-      OWNER: ${{ github.repository_owner }}
-      REPO: ${{ github.event.repository.name }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Check user permissions
-        id: check_user_permissions
-        working-directory: .github/.scripts
-        env:
-          USER: ${{ github.actor }}
-          PERMISSION: "write"
-        run: echo "result=$(./gh_user_check_permission.sh)" >> $GITHUB_OUTPUT
-
-      - name: Check PR permissions
-        id: check_pr_permissions
-        working-directory: .github/.scripts
-        env:
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          LABEL: "ci-approved"
-        run: echo "result=$(./gh_pull_request_check_label.sh)" >> $GITHUB_OUTPUT
-
-      - name: Combine permissions
-        run: |
-          user_allowed=${{ steps.check_user_permissions.outputs.result }}
-          pr_allowed=${{ steps.check_pr_permissions.outputs.result }}
-
-          [[ $user_allowed == "true" || $pr_allowed == "true" ]] && exit 0
-
-          echo "ERROR: User have no permissions to run CI and PR is not approved"
-          exit 1
-
-      - name: Checkout branch code
-        uses: actions/checkout@v4
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          path: branch_code
-          fetch-depth: 0
-
-      - name: Check fork PR branch contains latest base sha
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        working-directory: branch_code
-        run: git branch --contains $PULL_REQUEST_BASE_SHA
-        env:
-          PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-
   gh_build_image:
     runs-on: [ self-hosted, linux, k8s-runner-build ]
-
-    needs: [ check-ci-allowed ]
 
     permissions:
       packages: write
@@ -144,9 +48,6 @@ jobs:
       - uses: datalens-tech/cleanup-folder-action@v1
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: datalens-tech/fix-dubious-ownership-action@v1
 
       - id: build_image
@@ -160,8 +61,7 @@ jobs:
         env:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
-          # if pull_request_target use head sha, otherwise use github.sha
-          GIT_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          GIT_SHA: ${{ github.sha }}
 
   router:
     runs-on: [ self-hosted, linux, k8s-runner-no-compose ]
@@ -173,22 +73,17 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       changed-packages: ${{ steps.changed-packages.outputs.changed-packages }}
-    env:
-      PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
     - uses: datalens-tech/cleanup-folder-action@v1
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
         fetch-depth: 0
     - uses: datalens-tech/fix-dubious-ownership-action@v1
     - run: git fetch origin main
     - name: Extract base commit
       run: |
-        result="$PULL_REQUEST_BASE_SHA"
+        result="${{ github.event.before }}"
         if [ -z "$result" ]; then
             result=$(git rev-parse origin/main)
         fi
@@ -196,11 +91,7 @@ jobs:
       id: extract_base_commit
     - name: Extract head commit
       run: |
-        result="$PULL_REQUEST_HEAD_SHA"
-        if [ -z "$result" ]; then
-            result=$(git rev-parse HEAD)
-        fi
-        echo "result=$result" >> $GITHUB_OUTPUT
+        echo "result=${{ github.sha }}" >> $GITHUB_OUTPUT
       id: extract_head_commit
 
     - uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
@@ -236,45 +127,12 @@ jobs:
           ./lib/*
           ./app/*
         package-dependencies-resolution-method: >-
-          ${{
-            (
-              github.event.inputs.run_for_all_packages == 'true'
-              || contains(github.event.pull_request.labels.*.name, 'run-ci-for-all-packages')
-            ) && 'poetry-all' || 'poetry-path'
-          }}
+          ${{ github.event.inputs.run_for_all_packages == 'true' && 'poetry-all' || 'poetry-path' }}
         poetry-path-dependencies-groups: |
           tool.poetry.dependencies
           tool.poetry.group.tests.dependencies
         changed-packages-format: json
         changed-packages-relative-path: true
-
-  check-skip-tests-label:
-    name: Check PR skip tests label
-    runs-on: ubuntu-22.04
-
-    needs: [ check-ci-allowed ]
-
-    permissions:
-      contents: read
-      pull-requests: read
-
-    outputs:
-      result: ${{ steps.check_skip_label.outputs.result }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Check PR skip label
-        id: check_skip_label
-        working-directory: .github/.scripts
-        env:
-          GH_TOKEN: ${{ github.token }}
-          OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.event.repository.name }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-          LABEL: "tests-force-skipped"
-        run: echo "result=$(./gh_pull_request_check_label.sh)" >> $GITHUB_OUTPUT
 
   pytest_split:
     name: Split pytest into jobs for each test type
@@ -282,9 +140,8 @@ jobs:
 
     needs:
       - router
-      - check-skip-tests-label
       - gh_build_image
-    if: ${{ needs.check-skip-tests-label.outputs.result != 'true' && github.event.inputs.skip_tests != 'true' }}
+    if: ${{ github.event.inputs.skip_tests != 'true' }}
     container:
       image: ${{ needs.gh_build_image.outputs.IMAGE }}
       credentials:
@@ -300,8 +157,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 1
       - uses: datalens-tech/fix-dubious-ownership-action@v1
       - name: Run python script to split job for general and fat runners
@@ -584,8 +439,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 1
       - uses: datalens-tech/fix-dubious-ownership-action@v1
       - name: run mypy
@@ -609,7 +462,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     needs:
-      - check-skip-tests-label
       - pytest_split
       - run_tests_base
       - run_tests_fat
@@ -639,8 +491,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 1
       - uses: datalens-tech/fix-dubious-ownership-action@v1
       - run: task --silent dev:black


### PR DESCRIPTION
## Summary
- Drop `pull_request_target` and `workflow_dispatch` PR scaffolding from `.github/workflows/main.yml`. Triggers reduce to **push on main** + **workflow_dispatch**.
- Robot syncs commits directly to \`main\`, so the fork-PR safety jobs (\`drop-ci-approved-label\`, \`check-ci-allowed\`, \`check-skip-tests-label\`) and \`ci-approved\`/\`tests-force-skipped\` label flow no longer apply — removed.
- All checkouts drop the \`ref:\` / \`repository:\` overrides (defaults to the push ref).
- \`router\`: base SHA comes from \`github.event.before\` for push (falls back to \`origin/main\` for manual dispatch); head SHA is \`github.sha\`.
- \`concurrency\` group keyed on \`github.sha\` so every commit gets its own run (cancellation only applies to re-runs of the same commit).

Part of [BI-7421](https://st.yandex-team.ru/BI-7421). Unblocks failure notifications and BI-7423 (release-any-commit).

Follow-ups (separate PRs, not in this one):
- \`.github/.scripts/gh_user_check_permission.sh\` and \`gh_pull_request_check_label.sh\` are now orphaned — delete in a cleanup PR.
- \`terrarium_check.yaml\` still has \`pull_request\` trigger; same simplification later.
- \`validate-pr-name.yml\`, \`request-copilot.yaml\` — decide fate when fork-PR story is settled.

## Test plan
- [ ] Merge → first push to \`main\` triggers the workflow and runs all jobs end-to-end (image build, router, pytest split, mypy, codestyle).
- [ ] Verify \`router\` correctly diffs \`github.event.before\`..\`github.sha\` (changed-packages output non-empty when the synced commits touched \`lib/\` or \`app/\`).
- [ ] Verify \`workflow_dispatch\` with \`run_for_all_packages=true\` still tests everything.
- [ ] Verify \`workflow_dispatch\` with \`skip_tests=true\` skips pytest jobs.